### PR TITLE
fix: SELECT DISTINCT ORDER BY compatibility in getLinkedFragments

### DIFF
--- a/lib/memory/FragmentStore.js
+++ b/lib/memory/FragmentStore.js
@@ -425,18 +425,17 @@ export class FragmentStore {
       result = await queryWithAgentVector(agentId,
         `SELECT DISTINCT f.id, f.content, f.topic, f.keywords, f.type,
                          f.importance, f.linked_to, f.access_count,
-                         f.created_at, f.verified_at, l.relation_type
+                         f.created_at, f.verified_at, l.relation_type,
+                         CASE l.relation_type
+                           WHEN 'resolved_by' THEN 1
+                           WHEN 'caused_by'   THEN 2
+                           ELSE 3
+                         END AS relation_rank
          FROM ${SCHEMA}.fragment_links l
          JOIN ${SCHEMA}.fragments f ON l.to_id = f.id
          WHERE l.from_id = ANY($1)
            AND l.relation_type = $2
-         ORDER BY
-           CASE l.relation_type
-             WHEN 'resolved_by' THEN 1
-             WHEN 'caused_by'   THEN 2
-             ELSE 3
-           END,
-           f.importance DESC
+         ORDER BY relation_rank, f.importance DESC
          LIMIT ${MEMORY_CONFIG.linkedFragmentLimit}`,
         [fromIds, safeRelationType]
       );
@@ -444,18 +443,17 @@ export class FragmentStore {
       result = await queryWithAgentVector(agentId,
         `SELECT DISTINCT f.id, f.content, f.topic, f.keywords, f.type,
                          f.importance, f.linked_to, f.access_count,
-                         f.created_at, f.verified_at, l.relation_type
+                         f.created_at, f.verified_at, l.relation_type,
+                         CASE l.relation_type
+                           WHEN 'resolved_by' THEN 1
+                           WHEN 'caused_by'   THEN 2
+                           ELSE 3
+                         END AS relation_rank
          FROM ${SCHEMA}.fragment_links l
          JOIN ${SCHEMA}.fragments f ON l.to_id = f.id
          WHERE l.from_id = ANY($1)
            AND l.relation_type IN ('caused_by', 'resolved_by', 'related')
-         ORDER BY
-           CASE l.relation_type
-             WHEN 'resolved_by' THEN 1
-             WHEN 'caused_by'   THEN 2
-             ELSE 3
-           END,
-           f.importance DESC
+         ORDER BY relation_rank, f.importance DESC
          LIMIT ${MEMORY_CONFIG.linkedFragmentLimit}`,
         [fromIds]
       );


### PR DESCRIPTION
## Summary
- PostgreSQL requires all ORDER BY expressions to appear in the SELECT list when using SELECT DISTINCT
- The CASE expression on `l.relation_type` was only in ORDER BY, causing a runtime error when `recall` triggers `getLinkedFragments`
- Fix: add the CASE as a `relation_rank` alias in the SELECT list and reference it in ORDER BY

Error: `for SELECT DISTINCT, ORDER BY expressions must appear in select list`