### PR TITLE
feat: replace OpenAI embeddings with local HuggingFace model

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -60,10 +60,12 @@ export const CACHE_ENABLED      = process.env.CACHE_ENABLED === "true" || REDIS_
 export const CACHE_DB_TTL       = Number(process.env.CACHE_DB_TTL || 300);        // 5분
 export const CACHE_SESSION_TTL  = Number(process.env.CACHE_SESSION_TTL || SESSION_TTL_MS / 1000); // 세션과 동일
 
-/** OpenAI API 설정 */
-export const OPENAI_API_KEY     = process.env.OPENAI_API_KEY || "";
-export const EMBEDDING_MODEL    = process.env.EMBEDDING_MODEL || "text-embedding-3-small";
-export const EMBEDDING_DIMENSIONS = Number(process.env.EMBEDDING_DIMENSIONS || 1536);
+/** 임베딩 설정: OPENAI_API_KEY 설정 시 OpenAI, 미설정 시 로컬 HuggingFace 모델 */
+export const OPENAI_API_KEY       = process.env.OPENAI_API_KEY || "";
+export const EMBEDDING_MODEL      = process.env.EMBEDDING_MODEL ||
+  (OPENAI_API_KEY ? "text-embedding-3-small" : "Xenova/all-MiniLM-L6-v2");
+export const EMBEDDING_DIMENSIONS = Number(process.env.EMBEDDING_DIMENSIONS ||
+  (OPENAI_API_KEY ? 1536 : 384));
 
 /** NLI 서비스 설정 (미설정 시 in-process ONNX 모델 로드) */
 export const NLI_SERVICE_URL    = process.env.NLI_SERVICE_URL || "";

--- a/lib/memory/FragmentSearch.js
+++ b/lib/memory/FragmentSearch.js
@@ -11,7 +11,7 @@
 
 import { FragmentStore }             from "./FragmentStore.js";
 import { FragmentIndex }             from "./FragmentIndex.js";
-import { generateEmbedding, prepareTextForEmbedding, OPENAI_API_KEY } from "../tools/embedding.js";
+import { generateEmbedding, prepareTextForEmbedding, isEmbeddingAvailable } from "../tools/embedding.js";
 import { MEMORY_CONFIG }             from "../../config/memory.js";
 
 const CHARS_PER_TOKEN = 4;
@@ -60,7 +60,7 @@ export class FragmentSearch {
     }
 
     /** L3: pgvector 시맨틱 검색 */
-    if (candidates.length < 3 && query.text && OPENAI_API_KEY) {
+    if (candidates.length < 3 && query.text && isEmbeddingAvailable()) {
       const l3Results = await this._searchL3(query.text, agentId);
       if (l3Results.length > 0) {
         searchPath.push(`L3:${l3Results.length}`);

--- a/lib/memory/FragmentStore.js
+++ b/lib/memory/FragmentStore.js
@@ -13,7 +13,7 @@ import {
   prepareTextForEmbedding,
   generateEmbedding,
   vectorToSql,
-  OPENAI_API_KEY
+  isEmbeddingAvailable
 } from "../tools/embedding.js";
 
 const SCHEMA = "agent_memory";
@@ -64,7 +64,7 @@ export class FragmentStore {
     }
 
     let embeddingStr = null;
-    if (fragment.importance > 0.5 && OPENAI_API_KEY) {
+    if (fragment.importance > 0.5 && isEmbeddingAvailable()) {
       try {
         const text = prepareTextForEmbedding(fragment.content, 500);
         const vec  = await generateEmbedding(text);
@@ -584,7 +584,7 @@ export class FragmentStore {
      * 누락된 임베딩 보충 (유지보수용 - 'system' 컨텍스트 사용)
      */
   async generateMissingEmbeddings(batchSize = 10) {
-    if (!OPENAI_API_KEY) return 0;
+    if (!isEmbeddingAvailable()) return 0;
 
     const result = await queryWithAgentVector("system",
       `SELECT id, content FROM ${SCHEMA}.fragments

--- a/lib/memory/memory-schema.sql
+++ b/lib/memory/memory-schema.sql
@@ -31,7 +31,9 @@ CREATE TABLE IF NOT EXISTS agent_memory.fragments (
     estimated_tokens INTEGER DEFAULT 0,
     utility_score    REAL DEFAULT 1.0,
     verified_at      TIMESTAMPTZ DEFAULT NOW(),
-    embedding        vector(1536)
+    -- 로컬 모델(Xenova/all-MiniLM-L6-v2): vector(384)
+    -- OpenAI(text-embedding-3-small): vector(1536)
+    embedding        vector(384)
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_frag_hash

--- a/lib/tools/embedding.js
+++ b/lib/tools/embedding.js
@@ -3,32 +3,144 @@
  *
  * 작성자: 최진호
  * 작성일: 2026-02-23
- * 설명: OpenAI text-embedding-3-small API를 사용한 문서 벡터화
+ * 수정일: 2026-03-01
+ * 설명: 듀얼 모드 임베딩 (OpenAI API / 로컬 HuggingFace ONNX)
+ *       OPENAI_API_KEY 설정 시 OpenAI, 미설정 시 로컬 모델 자동 선택
  *       SHA-256 해시를 통한 변경 감지 및 중복 탐지
  */
 
 import { createHash } from "crypto";
-import OpenAI from "openai";
 import {
   OPENAI_API_KEY,
   EMBEDDING_MODEL,
   EMBEDDING_DIMENSIONS
 } from "../config.js";
 
-/** OpenAI 클라이언트 (lazy 초기화) */
-let openaiClient = null;
+const USE_OPENAI = !!OPENAI_API_KEY;
+
+/** ─── OpenAI 백엔드 ─── */
+
+let _openaiClient = null;
+
+async function getOpenAIClient() {
+  if (_openaiClient) return _openaiClient;
+
+  const { default: OpenAI } = await import("openai");
+  _openaiClient = new OpenAI({ apiKey: OPENAI_API_KEY });
+  return _openaiClient;
+}
+
+async function generateEmbeddingOpenAI(text) {
+  const client   = await getOpenAIClient();
+  const response = await client.embeddings.create({
+    model: EMBEDDING_MODEL,
+    input: text
+  });
+  return response.data[0].embedding;
+}
+
+async function generateBatchEmbeddingsOpenAI(texts, batchSize = 100) {
+  const client     = await getOpenAIClient();
+  const allVectors = [];
+
+  for (let i = 0; i < texts.length; i += batchSize) {
+    const batch    = texts.slice(i, i + batchSize);
+    const response = await client.embeddings.create({
+      model: EMBEDDING_MODEL,
+      input: batch
+    });
+
+    const sorted = response.data.sort((a, b) => a.index - b.index);
+    for (const item of sorted) {
+      allVectors.push(item.embedding);
+    }
+
+    if (i + batchSize < texts.length) {
+      await new Promise(r => setTimeout(r, 100));
+    }
+  }
+
+  return allVectors;
+}
+
+/** ─── 로컬 HuggingFace 백엔드 ─── */
+
+let _pipeline = null;
+let _loading  = null;
+let _failed   = false;
+
+async function getEmbeddingPipeline() {
+  if (_pipeline) return _pipeline;
+  if (_failed) return null;
+  if (_loading) return _loading;
+
+  _loading = (async () => {
+    try {
+      const { pipeline } = await import("@huggingface/transformers");
+
+      console.log(`[Embedding] Loading model: ${EMBEDDING_MODEL} ...`);
+      const t0 = Date.now();
+
+      _pipeline = await pipeline("feature-extraction", EMBEDDING_MODEL, {
+        dtype: "fp32"
+      });
+
+      const sec = ((Date.now() - t0) / 1000).toFixed(1);
+      console.log(`[Embedding] Model ready in ${sec}s (dims: ${EMBEDDING_DIMENSIONS})`);
+
+      return _pipeline;
+    } catch (err) {
+      console.warn(`[Embedding] Model load failed: ${err.message}`);
+      _failed = true;
+      return null;
+    } finally {
+      _loading = null;
+    }
+  })();
+
+  return _loading;
+}
+
+async function generateEmbeddingLocal(text) {
+  const pipe = await getEmbeddingPipeline();
+  if (!pipe) {
+    throw new Error("임베딩 모델을 로드할 수 없습니다");
+  }
+
+  const output = await pipe(text, { pooling: "mean", normalize: true });
+  return Array.from(output.data);
+}
+
+async function generateBatchEmbeddingsLocal(texts, batchSize = 32) {
+  const pipe = await getEmbeddingPipeline();
+  if (!pipe) {
+    throw new Error("임베딩 모델을 로드할 수 없습니다");
+  }
+
+  const allVectors = [];
+
+  for (let i = 0; i < texts.length; i += batchSize) {
+    const batch = texts.slice(i, i + batchSize);
+
+    for (const text of batch) {
+      const output = await pipe(text, { pooling: "mean", normalize: true });
+      allVectors.push(Array.from(output.data));
+    }
+  }
+
+  return allVectors;
+}
+
+/** ─── 공용 API ─── */
 
 /**
- * OpenAI 클라이언트 싱글톤
+ * 임베딩 사용 가능 여부 (동기)
+ * OpenAI 모드: API 키가 설정되어 있으면 항상 true
+ * 로컬 모드: 모델 로드 실패 시에만 false
  */
-function getOpenAIClient() {
-  if (!openaiClient) {
-    if (!OPENAI_API_KEY) {
-      throw new Error("OPENAI_API_KEY 환경변수가 설정되지 않았습니다");
-    }
-    openaiClient = new OpenAI({ apiKey: OPENAI_API_KEY });
-  }
-  return openaiClient;
+export function isEmbeddingAvailable() {
+  if (USE_OPENAI) return true;
+  return !_failed;
 }
 
 /**
@@ -82,50 +194,23 @@ export function prepareTextForEmbedding(content, maxTokens = 8000) {
  * 단일 텍스트의 임베딩 벡터 생성
  *
  * @param {string} text - 임베딩할 텍스트
- * @returns {Promise<number[]>} 1536차원 벡터
+ * @returns {Promise<number[]>} 벡터 (차원은 설정에 따라 다름)
  */
 export async function generateEmbedding(text) {
-  const client = getOpenAIClient();
-
-  const response = await client.embeddings.create({
-    model: EMBEDDING_MODEL,
-    input: text
-  });
-
-  return response.data[0].embedding;
+  if (USE_OPENAI) return generateEmbeddingOpenAI(text);
+  return generateEmbeddingLocal(text);
 }
 
 /**
  * 배치 임베딩 생성 (여러 텍스트 동시 처리)
- * OpenAI API는 한 번의 호출로 최대 2048개 입력을 처리할 수 있다
  *
  * @param {string[]} texts      - 임베딩할 텍스트 배열
- * @param {number}   batchSize  - API 호출당 처리 단위 (기본 100)
+ * @param {number}   batchSize  - 호출당 처리 단위
  * @returns {Promise<number[][]>} 각 텍스트의 벡터 배열
  */
-export async function generateBatchEmbeddings(texts, batchSize = 100) {
-  const client    = getOpenAIClient();
-  const allVectors = [];
-
-  for (let i = 0; i < texts.length; i += batchSize) {
-    const batch    = texts.slice(i, i + batchSize);
-    const response = await client.embeddings.create({
-      model: EMBEDDING_MODEL,
-      input: batch
-    });
-
-    const sorted = response.data.sort((a, b) => a.index - b.index);
-    for (const item of sorted) {
-      allVectors.push(item.embedding);
-    }
-
-    /** rate limit 방어: 배치 간 100ms 대기 */
-    if (i + batchSize < texts.length) {
-      await new Promise(r => setTimeout(r, 100));
-    }
-  }
-
-  return allVectors;
+export async function generateBatchEmbeddings(texts, batchSize) {
+  if (USE_OPENAI) return generateBatchEmbeddingsOpenAI(texts, batchSize || 100);
+  return generateBatchEmbeddingsLocal(texts, batchSize || 32);
 }
 
 /**
@@ -209,4 +294,4 @@ export function vectorToSql(vector) {
   return `[${vector.join(",")}]`;
 }
 
-export { OPENAI_API_KEY, EMBEDDING_MODEL, EMBEDDING_DIMENSIONS };
+export { EMBEDDING_MODEL, EMBEDDING_DIMENSIONS };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,13 +7,13 @@
     "": {
       "name": "memento-mcp",
       "version": "1.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "ioredis": "^5.9.3",
         "js-tiktoken": "^1.0.21",
         "node-fetch": "^3.3.2",
-        "openai": "^6.21.0",
         "pg": "^8.18.0",
         "prom-client": "^15.1.3",
         "winston": "^3.19.0",
@@ -958,7 +958,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1567,7 +1566,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1751,7 +1749,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2170,7 +2167,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
       "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2777,27 +2773,6 @@
       "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
       "license": "MIT"
     },
-    "node_modules/openai": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.25.0.tgz",
-      "integrity": "sha512-mEh6VZ2ds2AGGokWARo18aPISI1OhlgdEIC1ewhkZr8pSIT31dec0ecr9Nhxx0JlybyOgoAT1sWeKtwPZzJyww==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2904,7 +2879,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.19.0.tgz",
       "integrity": "sha512-QIcLGi508BAHkQ3pJNptsFz5WQMlpGbuBGBaIaXsWK8mel2kQ/rThYI+DbgjUvZrIr7MiuEuc9LcChJoEZK1xQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.12.0",
@@ -3733,7 +3707,6 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
       "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",
@@ -3835,7 +3808,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "ioredis": "^5.9.3",
     "js-tiktoken": "^1.0.21",
     "node-fetch": "^3.3.2",
-    "openai": "^6.21.0",
     "pg": "^8.18.0",
     "prom-client": "^15.1.3",
     "winston": "^3.19.0",


### PR DESCRIPTION
## Summary
- Add local HuggingFace embedding support as a free alternative to OpenAI
- Auto-selects backend based on `OPENAI_API_KEY`: set = OpenAI, absent = local model
- Local model: `Xenova/all-MiniLM-L6-v2` (384 dims, ~23MB ONNX, CPU)
- No new dependencies; uses existing `@huggingface/transformers`
- OpenAI backend preserved with dynamic import (install `openai` if needed)
- Smart defaults: `EMBEDDING_MODEL` and `EMBEDDING_DIMENSIONS` auto-set per backend
- Schema defaults to `vector(384)`; OpenAI users change to `vector(1536)`