### PR TITLE
fix: recall returning empty results, embedding client ignoring OPENAI…

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,215 @@
+# Docker Guide — Memento MCP Server
+
+## Prerequisites
+
+- Docker 19.03+ (with BuildKit) or Docker Desktop
+- A PostgreSQL 16+ instance with the `pgvector` extension (0.5.0+)
+
+## Database Setup (one-time)
+
+Before starting the container, initialise the schema on your PostgreSQL server:
+
+```bash
+psql -U $POSTGRES_USER -d $POSTGRES_DB -c "CREATE EXTENSION IF NOT EXISTS vector;"
+psql -U $POSTGRES_USER -d $POSTGRES_DB -f lib/memory/memory-schema.sql
+```
+
+Verify with `\dx` in psql — the HNSW index requires pgvector 0.5.0 or later.
+
+---
+
+## Quick Start (single-platform build)
+
+```bash
+# Build
+docker build -t memento-mcp .
+
+# Run
+docker run -d \
+  --name memento-mcp \
+  -p 56332:56332 \
+  -e POSTGRES_HOST=host.docker.internal \
+  -e POSTGRES_PORT=5432 \
+  -e POSTGRES_DB=your_db \
+  -e POSTGRES_USER=your_user \
+  -e POSTGRES_PASSWORD=your_password \
+  -e MEMENTO_ACCESS_KEY=your_secret_key \
+  memento-mcp
+```
+
+## Multi-platform Build & Push to Docker Hub
+
+Build for both `linux/amd64` and `linux/arm64` and push directly to Docker Hub:
+
+```bash
+# 1. Create a buildx builder (first time only)
+docker buildx create --name memento-builder --use
+docker buildx inspect --bootstrap
+
+# 2. Log in to Docker Hub
+docker login
+
+# 3. Build & push (replace myaccount with your Docker Hub username)
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --tag myaccount/memento-mcp:latest \
+  --tag myaccount/memento-mcp:1.0.1 \
+  --push \
+  .
+```
+
+To build locally without pushing (single platform, loads into local Docker):
+
+```bash
+docker buildx build --load -t memento-mcp .
+```
+
+---
+
+## Environment Variables
+
+### Required
+
+| Variable | Description |
+|----------|-------------|
+| `POSTGRES_HOST` | PostgreSQL hostname |
+| `POSTGRES_PORT` | PostgreSQL port (default `5432`) |
+| `POSTGRES_DB` | Database name |
+| `POSTGRES_USER` | Database user |
+| `POSTGRES_PASSWORD` | Database password |
+
+### Recommended
+
+| Variable | Description |
+|----------|-------------|
+| `MEMENTO_ACCESS_KEY` | Bearer token for client auth (empty = auth disabled) |
+
+### Optional
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `56332` | HTTP listen port |
+| `SESSION_TTL_MINUTES` | `60` | Session idle timeout |
+| `LOG_DIR` | `/var/log/mcp` | Winston log directory |
+| `ALLOWED_ORIGINS` | _(empty)_ | Comma-separated CORS origins |
+| `REDIS_ENABLED` | `false` | Enable Redis caching |
+| `REDIS_HOST` | `localhost` | Redis host |
+| `REDIS_PORT` | `6379` | Redis port |
+| `REDIS_PASSWORD` | _(empty)_ | Redis password |
+| `OPENAI_API_KEY` | _(empty)_ | For L3 embedding search |
+| `OPENAI_BASE_URL` | _(empty)_ | Custom OpenAI-compatible API base URL (e.g. LM Studio, Ollama) |
+| `EMBEDDING_MODEL` | `text-embedding-3-small` | OpenAI embedding model |
+| `EMBEDDING_DIMENSIONS` | `1536` | Embedding vector dimensions (must match model output) |
+| `NLI_SERVICE_URL` | _(empty)_ | External NLI service (skips in-process ONNX model) |
+
+You can pass all variables via an env file:
+
+```bash
+docker run -d --env-file .env -p 56332:56332 memento-mcp
+```
+
+---
+
+## Health Check
+
+The container has a built-in health check that polls the `/health` endpoint every 30 seconds (with a 40-second start-up grace period to allow NLI model preloading).
+
+```bash
+docker inspect --format='{{.State.Health.Status}}' memento-mcp
+```
+
+## Logs
+
+Application logs are written to `/var/log/mcp` inside the container. Mount a volume to persist them:
+
+```bash
+docker run -d \
+  -v memento-logs:/var/log/mcp \
+  -p 56332:56332 \
+  --env-file .env \
+  memento-mcp
+```
+
+## Monitoring
+
+Prometheus metrics are exposed at `/metrics`:
+
+```bash
+curl http://localhost:56332/metrics
+```
+
+---
+
+## Docker Compose Example
+
+```yaml
+services:
+  memento-mcp:
+    build: .
+    # Or use a pre-built image:
+    # image: myaccount/memento-mcp:latest
+    ports:
+      - "56332:56332"
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DB: memento
+      POSTGRES_USER: memento
+      POSTGRES_PASSWORD: changeme
+      MEMENTO_ACCESS_KEY: changeme
+    volumes:
+      - memento-logs:/var/log/mcp
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_DB: memento
+      POSTGRES_USER: memento
+      POSTGRES_PASSWORD: changeme
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./lib/memory/memory-schema.sql:/docker-entrypoint-initdb.d/01-schema.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U memento"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  pgdata:
+  memento-logs:
+```
+
+Start the full stack:
+
+```bash
+docker compose up -d
+```
+
+This uses the `pgvector/pgvector:pg16` image which ships with the `vector` extension pre-installed, and mounts the schema SQL into the PostgreSQL init directory so the database is ready on first boot.
+
+---
+
+## MCP Client Configuration
+
+Once the server is running, point your MCP client at it:
+
+```json
+{
+  "mcpServers": {
+    "memento": {
+      "type": "http",
+      "url": "http://localhost:56332/mcp",
+      "headers": {
+        "Authorization": "Bearer ${MEMENTO_ACCESS_KEY}"
+      }
+    }
+  }
+}
+```
+
+For external access, place the service behind a reverse proxy with TLS termination.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# ---- Build stage: install production dependencies ----
+FROM node:22-slim AS deps
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+# Force CPU-only ONNX Runtime (avoids CUDA 11 build failures).
+RUN npm ci --omit=dev --onnxruntime-node-install-cuda=skip
+
+# ---- Runtime stage ----
+FROM node:22-slim
+
+LABEL org.opencontainers.image.title="memento-mcp" \
+      org.opencontainers.image.description="Fragment-Based Memory MCP Server" \
+      org.opencontainers.image.source="https://github.com/anthropics/memento-mcp" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+WORKDIR /app
+
+# Create log directory and a non-root user.
+RUN mkdir -p /var/log/mcp /home/mcp/.cache \
+    && addgroup --system --gid 1001 mcp \
+    && adduser  --system --uid 1001 --ingroup mcp mcp \
+    && chown mcp:mcp /var/log/mcp /home/mcp/.cache
+
+# Redirect HuggingFace model cache to a writable directory.
+ENV HF_HOME=/home/mcp/.cache/huggingface
+
+# Copy production node_modules from build stage.
+COPY --from=deps /app/node_modules ./node_modules
+
+# The @huggingface/transformers package writes a browser-style cache inside its
+# own package directory, ignoring HF_HOME.  Pre-create it so the non-root user
+# can write to it.
+RUN mkdir -p /app/node_modules/@huggingface/transformers/.cache \
+    && chown -R mcp:mcp /app/node_modules/@huggingface/transformers/.cache
+
+# Copy application source.
+COPY package.json ./
+COPY server.js    ./
+COPY lib/         ./lib/
+COPY config/      ./config/
+
+# Drop to non-root.
+USER mcp
+
+EXPOSE 56332
+
+# Health check against the built-in /health endpoint.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+    CMD node -e "fetch('http://localhost:${PORT||56332}/health').then(r=>{if(!r.ok)throw r.status}).catch(()=>process.exit(1))"
+
+# Graceful shutdown: the server handles SIGTERM.
+STOPSIGNAL SIGTERM
+
+CMD ["node", "server.js"]

--- a/lib/config.js
+++ b/lib/config.js
@@ -61,8 +61,9 @@ export const CACHE_DB_TTL       = Number(process.env.CACHE_DB_TTL || 300);      
 export const CACHE_SESSION_TTL  = Number(process.env.CACHE_SESSION_TTL || SESSION_TTL_MS / 1000); // 세션과 동일
 
 /** OpenAI API 설정 */
-export const OPENAI_API_KEY     = process.env.OPENAI_API_KEY || "";
-export const EMBEDDING_MODEL    = process.env.EMBEDDING_MODEL || "text-embedding-3-small";
+export const OPENAI_API_KEY       = process.env.OPENAI_API_KEY || "";
+export const OPENAI_BASE_URL      = process.env.OPENAI_BASE_URL || "";
+export const EMBEDDING_MODEL      = process.env.EMBEDDING_MODEL || "text-embedding-3-small";
 export const EMBEDDING_DIMENSIONS = Number(process.env.EMBEDDING_DIMENSIONS || 1536);
 
 /** NLI 서비스 설정 (미설정 시 in-process ONNX 모델 로드) */

--- a/lib/memory/FragmentSearch.js
+++ b/lib/memory/FragmentSearch.js
@@ -102,17 +102,17 @@ export class FragmentSearch {
 
     if (query.keywords && query.keywords.length > 0) {
       const kwIds = await this.index.searchByKeywords(query.keywords);
-      sets.push(new Set(kwIds));
+      if (kwIds.length > 0) sets.push(new Set(kwIds));
     }
 
     if (query.topic) {
       const topicIds = await this.index.searchByTopic(query.topic);
-      sets.push(new Set(topicIds));
+      if (topicIds.length > 0) sets.push(new Set(topicIds));
     }
 
     if (query.type) {
       const typeIds = await this.index.searchByType(query.type);
-      sets.push(new Set(typeIds));
+      if (typeIds.length > 0) sets.push(new Set(typeIds));
     }
 
     if (sets.length === 0) {
@@ -156,6 +156,11 @@ export class FragmentSearch {
 
     if (query.keywords && query.keywords.length > 0) {
       results = await this.store.searchByKeywords(query.keywords, options);
+    }
+
+    /** Topic-only PostgreSQL fallback when keywords produced nothing */
+    if (results.length === 0 && query.topic) {
+      results = await this.store.searchByTopic(query.topic, options);
     }
 
     /** 추가 ID 기반 조회 (L1에서 찾은 것 중 캐시 미스분) */

--- a/lib/memory/FragmentStore.js
+++ b/lib/memory/FragmentStore.js
@@ -213,6 +213,46 @@ export class FragmentStore {
   }
 
   /**
+     * 토픽 기반 검색 (L2 fallback)
+     */
+  async searchByTopic(topic, options = {}) {
+    const agentId = options.agentId || "default";
+    const conditions = ["topic = $1"];
+    const params     = [topic];
+    let paramIdx     = 2;
+
+    if (options.type) {
+      conditions.push(`type = $${paramIdx}`);
+      params.push(options.type);
+      paramIdx++;
+    }
+    if (options.minImportance) {
+      conditions.push(`importance >= $${paramIdx}`);
+      params.push(options.minImportance);
+      paramIdx++;
+    }
+
+    const limit = options.limit || 20;
+    params.push(limit);
+
+    const result = await queryWithAgentVector(agentId,
+      `SELECT f.id, f.content, f.topic, f.keywords, f.type, f.importance,
+                    f.linked_to, f.access_count, f.created_at, f.verified_at, f.is_anchor
+             FROM ${SCHEMA}.fragments f
+             WHERE ${conditions.join(" AND ")}
+               AND NOT EXISTS (
+                 SELECT 1 FROM ${SCHEMA}.fragment_links l
+                 WHERE l.from_id = f.id AND l.relation_type = 'superseded_by'
+               )
+             ORDER BY f.importance DESC, f.created_at DESC
+             LIMIT $${paramIdx}`,
+      params
+    );
+
+    return result.rows;
+  }
+
+  /**
      * 벡터 유사도 검색
      */
   async searchBySemantic(queryEmbedding, limit = 10, minSimilarity = 0.3, agentId = "default") {
@@ -423,39 +463,37 @@ export class FragmentStore {
     let result;
     if (safeRelationType) {
       result = await queryWithAgentVector(agentId,
-        `SELECT DISTINCT f.id, f.content, f.topic, f.keywords, f.type,
+        `SELECT DISTINCT ON (f.id) f.id, f.content, f.topic, f.keywords, f.type,
                          f.importance, f.linked_to, f.access_count,
-                         f.created_at, f.verified_at, l.relation_type
+                         f.created_at, f.verified_at, l.relation_type,
+                         CASE l.relation_type
+                           WHEN 'resolved_by' THEN 1
+                           WHEN 'caused_by'   THEN 2
+                           ELSE 3
+                         END AS relation_order
          FROM ${SCHEMA}.fragment_links l
          JOIN ${SCHEMA}.fragments f ON l.to_id = f.id
          WHERE l.from_id = ANY($1)
            AND l.relation_type = $2
-         ORDER BY
-           CASE l.relation_type
-             WHEN 'resolved_by' THEN 1
-             WHEN 'caused_by'   THEN 2
-             ELSE 3
-           END,
-           f.importance DESC
+         ORDER BY f.id, relation_order, f.importance DESC
          LIMIT ${MEMORY_CONFIG.linkedFragmentLimit}`,
         [fromIds, safeRelationType]
       );
     } else {
       result = await queryWithAgentVector(agentId,
-        `SELECT DISTINCT f.id, f.content, f.topic, f.keywords, f.type,
+        `SELECT DISTINCT ON (f.id) f.id, f.content, f.topic, f.keywords, f.type,
                          f.importance, f.linked_to, f.access_count,
-                         f.created_at, f.verified_at, l.relation_type
+                         f.created_at, f.verified_at, l.relation_type,
+                         CASE l.relation_type
+                           WHEN 'resolved_by' THEN 1
+                           WHEN 'caused_by'   THEN 2
+                           ELSE 3
+                         END AS relation_order
          FROM ${SCHEMA}.fragment_links l
          JOIN ${SCHEMA}.fragments f ON l.to_id = f.id
          WHERE l.from_id = ANY($1)
            AND l.relation_type IN ('caused_by', 'resolved_by', 'related')
-         ORDER BY
-           CASE l.relation_type
-             WHEN 'resolved_by' THEN 1
-             WHEN 'caused_by'   THEN 2
-             ELSE 3
-           END,
-           f.importance DESC
+         ORDER BY f.id, relation_order, f.importance DESC
          LIMIT ${MEMORY_CONFIG.linkedFragmentLimit}`,
         [fromIds]
       );

--- a/lib/memory/memory-schema.sql
+++ b/lib/memory/memory-schema.sql
@@ -10,7 +10,7 @@
 
 CREATE SCHEMA IF NOT EXISTS agent_memory;
 
-SET search_path TO agent_memory, nerdvana, public;
+SET search_path TO agent_memory, public;
 
 -- 파편(Fragment) 테이블
 CREATE TABLE IF NOT EXISTS agent_memory.fragments (
@@ -140,9 +140,10 @@ ALTER TABLE agent_memory.fragments ENABLE ROW LEVEL SECURITY;
 -- 에이전트 격리 정책: 세션 변수 'app.current_agent_id'와 일치하는 데이터만 접근 허용
 -- agent_id가 'default'인 경우는 공용 데이터로 간주하여 조회 허용
 -- 'system' 또는 'admin' 세션은 모든 데이터에 접근 허용 (유지보수용)
+DROP POLICY IF EXISTS fragment_isolation_policy ON agent_memory.fragments;
 CREATE POLICY fragment_isolation_policy ON agent_memory.fragments
     USING (
-        agent_id = current_setting('app.current_agent_id', true) 
+        agent_id = current_setting('app.current_agent_id', true)
         OR agent_id = 'default'
         OR current_setting('app.current_agent_id', true) IN ('system', 'admin')
     );

--- a/lib/tools/db.js
+++ b/lib/tools/db.js
@@ -172,12 +172,18 @@ function getDataTypeName(oid) {
  * @param {any[]} params - 쿼리 파라미터
  */
 export async function queryWithAgent(agentId, sql, params = []) {
-  const pool   = getPool();
-  const client = await pool.connect();
+  const pool      = getPool();
+  const client    = await pool.connect();
+  const safeAgent = String(agentId || "default").replace(/[^a-zA-Z0-9_\-]/g, "");
   try {
-    // 세션 변수 설정 (RLS 정책용)
-    await client.query("SET LOCAL app.current_agent_id = $1", [agentId || "default"]);
-    return await client.query(sql, params);
+    await client.query("BEGIN");
+    await client.query(`SET LOCAL app.current_agent_id = '${safeAgent}'`);
+    const result = await client.query(sql, params);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
   } finally {
     client.release();
   }
@@ -191,10 +197,15 @@ export async function queryWithAgentVector(agentId, sql, params = []) {
   const client    = await pool.connect();
   const safeAgent = String(agentId || "default").replace(/[^a-zA-Z0-9_\-]/g, "");
   try {
-    const SCHEMA  = "agent_memory";
-    await client.query(`SET search_path TO ${SCHEMA}, nerdvana, public`);
+    await client.query("BEGIN");
+    await client.query(`SET LOCAL search_path TO agent_memory, public`);
     await client.query(`SET LOCAL app.current_agent_id = '${safeAgent}'`);
-    return await client.query(sql, params);
+    const result = await client.query(sql, params);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
   } finally {
     client.release();
   }

--- a/lib/tools/embedding.js
+++ b/lib/tools/embedding.js
@@ -26,7 +26,12 @@ function getOpenAIClient() {
     if (!OPENAI_API_KEY) {
       throw new Error("OPENAI_API_KEY 환경변수가 설정되지 않았습니다");
     }
-    openaiClient = new OpenAI({ apiKey: OPENAI_API_KEY });
+    const opts = { apiKey: OPENAI_API_KEY };
+    const baseURL = process.env.OPENAI_BASE_URL;
+    if (baseURL) {
+      opts.baseURL = baseURL;
+    }
+    openaiClient = new OpenAI(opts);
   }
   return openaiClient;
 }
@@ -87,10 +92,11 @@ export function prepareTextForEmbedding(content, maxTokens = 8000) {
 export async function generateEmbedding(text) {
   const client = getOpenAIClient();
 
-  const response = await client.embeddings.create({
-    model: EMBEDDING_MODEL,
-    input: text
-  });
+  const params = { model: EMBEDDING_MODEL, input: text };
+  if (EMBEDDING_DIMENSIONS) {
+    params.dimensions = parseInt(EMBEDDING_DIMENSIONS, 10);
+  }
+  const response = await client.embeddings.create(params);
 
   return response.data[0].embedding;
 }
@@ -109,10 +115,11 @@ export async function generateBatchEmbeddings(texts, batchSize = 100) {
 
   for (let i = 0; i < texts.length; i += batchSize) {
     const batch    = texts.slice(i, i + batchSize);
-    const response = await client.embeddings.create({
-      model: EMBEDDING_MODEL,
-      input: batch
-    });
+    const batchParams = { model: EMBEDDING_MODEL, input: batch };
+    if (EMBEDDING_DIMENSIONS) {
+      batchParams.dimensions = parseInt(EMBEDDING_DIMENSIONS, 10);
+    }
+    const response = await client.embeddings.create(batchParams);
 
     const sorted = response.data.sort((a, b) => a.index - b.index);
     for (const item of sorted) {

--- a/lib/tools/memory.js
+++ b/lib/tools/memory.js
@@ -425,7 +425,25 @@ export async function tool_recall(args) {
     SessionActivityTracker.record(sessionId, {
       tool: "recall", keywords: args.keywords || [args.text?.substring(0, 30)]
     }).catch(() => {});
-    return { success: true, ...result };
+
+    /** Return a cleaner response so the LLM can easily parse the content */
+    const fragments = result.fragments.map(f => ({
+      id        : f.id,
+      content   : f.content,
+      topic     : f.topic,
+      type      : f.type,
+      importance: f.importance,
+      ...(f.similarity !== undefined ? { similarity: f.similarity } : {}),
+      ...(f.metadata?.stale ? { stale_warning: f.metadata.warning } : {})
+    }));
+
+    return {
+      success    : true,
+      fragments,
+      count      : fragments.length,
+      totalTokens: result.totalTokens,
+      searchPath : result.searchPath
+    };
   } catch (err) {
     return { success: false, error: err.message };
   }


### PR DESCRIPTION
Recall was always returning empty due to several compounding bugs:

- L1 intersection poisoning: empty keyword results created an empty Set that killed valid topic matches via intersection. Now only non-empty result sets participate in the intersection.

- No L2 topic fallback: when L1 returned nothing (Redis down, empty intersection), L2 could only search by keywords or fetch L1 IDs. Added searchByTopic() to FragmentStore and a topic-only fallback path in L2.

- getLinkedFragments SQL error: SELECT DISTINCT with a CASE expression in ORDER BY that wasn't in the select list. This was a latent bug never triggered until recall started returning results. Changed to DISTINCT ON (f.id) with the CASE as a named column.

- SET LOCAL without transaction: queryWithAgent and queryWithAgentVector used SET LOCAL in autocommit mode, making RLS session variables expire immediately. Wrapped in BEGIN/COMMIT.

- Embedding client ignored OPENAI_BASE_URL: the OpenAI constructor only received apiKey, so the SDK defaulted to api.openai.com instead of local LM Studio. Now reads OPENAI_BASE_URL from env and passes it as baseURL.

- Embedding dimensions not passed to API: generateEmbedding() and generateBatchEmbeddings() now pass the dimensions parameter when EMBEDDING_DIMENSIONS is set.

- Vector dimension mismatch: schema hardcoded vector(1536) but local models produce different dimensions. Startup now auto-reconciles the column dimension with EMBEDDING_DIMENSIONS config.

- Schema auto-apply on startup: server now runs memory-schema.sql on boot with IF NOT EXISTS guards, including CREATE EXTENSION vector. Made CREATE POLICY idempotent with DROP IF EXISTS.

- Docker cache permissions: pre-create the @huggingface/transformers .cache directory with correct ownership for the non-root mcp user.

- Recall tool response cleanup: strip noisy metadata fields from fragment objects so LLMs can easily find the content.

- Removed stale nerdvana schema reference from search_path.

This has been manually tested with a custom agent.