### PR TITLE
Fix search_traces RLS bypass

### DIFF
--- a/lib/tools/reconstruct.js
+++ b/lib/tools/reconstruct.js
@@ -10,7 +10,7 @@
  */
 
 import { MemoryManager }  from "../memory/MemoryManager.js";
-import { getPrimaryPool } from "./db.js";
+import { getPrimaryPool, queryWithAgentVector } from "./db.js";
 import { logAudit }       from "../utils.js";
 
 export {
@@ -106,6 +106,7 @@ export async function tool_reconstructHistory(args) {
  * @param {string|null} [args._defaultWorkspace]
  */
 export async function tool_searchTraces(args) {
+  const agentId   = args.agentId            || "default";
   const keyId     = args._keyId             ?? null;
   const workspace = args.workspace          ?? args._defaultWorkspace ?? null;
   delete args._sessionId;
@@ -121,6 +122,7 @@ export async function tool_searchTraces(args) {
       session_id : args.sessionId  ?? args.session_id  ?? null,
       time_range : args.time_range  ?? null,
       limit,
+      agentId,
       keyId,
       workspace
     });
@@ -140,8 +142,7 @@ export async function tool_searchTraces(args) {
  *
  * @private
  */
-async function _queryFragmentTraces({ event_type, entity_key, keyword, case_id, session_id, time_range, limit, keyId, workspace }) {
-  const pool   = getPrimaryPool();
+async function _queryFragmentTraces({ event_type, entity_key, keyword, case_id, session_id, time_range, limit, agentId, keyId, workspace }) {
   const params = [];
 
   /** $1: case_id */
@@ -200,6 +201,6 @@ async function _queryFragmentTraces({ event_type, entity_key, keyword, case_id, 
      ORDER BY f.created_at DESC
      LIMIT $${limitIdx}`;
 
-  const { rows } = await pool.query(sql, params);
+  const { rows } = await queryWithAgentVector(agentId, sql, params);
   return rows;
 }

--- a/tests/unit/search-traces-rls.test.js
+++ b/tests/unit/search-traces-rls.test.js
@@ -1,0 +1,92 @@
+import { beforeEach, describe, mock, test } from "node:test";
+import assert from "node:assert/strict";
+
+const mockQueryWithAgentVector = mock.fn();
+
+mock.module("../../lib/tools/db.js", {
+  namedExports: {
+    getPrimaryPool: () => ({
+      query: () => {
+        throw new Error("search_traces must use queryWithAgentVector to preserve RLS");
+      }
+    }),
+    queryWithAgentVector: (...args) => mockQueryWithAgentVector(...args)
+  }
+});
+
+mock.module("../../lib/utils.js", {
+  namedExports: {
+    logAudit: mock.fn(async () => {})
+  }
+});
+
+mock.module("../../lib/memory/MemoryManager.js", {
+  namedExports: {
+    MemoryManager: class {
+      static getInstance() {
+        return new this();
+      }
+      async reconstructHistory() {
+        throw new Error("reconstructHistory should not be called in search_traces test");
+      }
+    }
+  }
+});
+
+const { tool_searchTraces } = await import("../../lib/tools/reconstruct.js");
+
+describe("search_traces RLS regression", () => {
+  beforeEach(() => {
+    mockQueryWithAgentVector.mock.resetCalls();
+  });
+
+  test("uses queryWithAgentVector with default agent context", async () => {
+    mockQueryWithAgentVector.mock.mockImplementationOnce(async () => ({
+      rows: [
+        {
+          id: "frag-default-visible",
+          content: "visible fragment",
+          type: "fact",
+          topic: "session_reflect",
+          case_id: null,
+          session_id: null,
+          resolution_status: null,
+          importance: 0.2,
+          created_at: "2026-04-20T00:00:00Z",
+          source: "fragment"
+        }
+      ]
+    }));
+
+    const result = await tool_searchTraces({
+      entity_key: "session_reflect",
+      keyword: "visible",
+      limit: 20
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.count, 1);
+    assert.equal(result.traces[0].id, "frag-default-visible");
+    assert.equal(mockQueryWithAgentVector.mock.callCount(), 1);
+
+    const [agentId, sql, params] = mockQueryWithAgentVector.mock.calls[0].arguments;
+    assert.equal(agentId, "default");
+    assert.match(sql, /FROM agent_memory\.fragments f/i);
+    assert.match(sql, /AND f\.valid_to IS NULL/i);
+    assert.equal(params[2], "%visible%");
+    assert.equal(params[3], "%session\\_reflect%");
+  });
+
+  test("forwards explicit agentId when provided", async () => {
+    mockQueryWithAgentVector.mock.mockImplementationOnce(async () => ({ rows: [] }));
+
+    const result = await tool_searchTraces({
+      agentId: "project-agentdesk",
+      entity_key: "session_reflect"
+    });
+
+    assert.equal(result.success, true);
+    const [agentId] = mockQueryWithAgentVector.mock.calls[0].arguments;
+    assert.equal(agentId, "project-agentdesk");
+  });
+});


### PR DESCRIPTION
## Summary\n- route search_traces through queryWithAgentVector so app.current_agent_id is set before querying fragments\n- stop bypassing fragment RLS via raw pool access in trace search\n- add a regression test that fails if search_traces falls back to getPrimaryPool\n\n## Testing\n- node --experimental-test-module-mocks --test tests/unit/search-traces-rls.test.js