### PR TITLE
LLM CLI fallback 설정 전달 보강 및 qwen-cli provider 추가

### DIFF
--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -1063,12 +1063,17 @@ LLM_PRIMARY=gemini-cli
 - Calls GitHub Copilot CLI (`gh copilot suggest`) as a wrapper
 - Uses `extractJsonBlock()` utility to strip trailing statistics/banner text before JSON extraction
 
+**qwen-cli provider** (`lib/llm/providers/QwenCliProvider.js`):
+- Wraps Alibaba Cloud Qwen Code CLI (`qwen`) in `--output-format text` mode
+- Extracts JSON block from text output. When `model` is omitted, the CLI default model is used
+- Requires `qwen auth` authentication
+
 **Circuit breaker and timeout** (`config/memory.js`):
 - `geminiTimeoutMs: 60000` (increased from 15000). Accommodates latency growth with large Gemini CLI prompts
 - Circuit breaker failure threshold (LLM_CB_FAILURE_THRESHOLD=5) and OPEN duration (LLM_CB_OPEN_DURATION_MS=60000) remain unchanged
 
 **Complete LLM_PRIMARY allowed values** (v2.9.0):
-`gemini-cli`, `anthropic`, `openai`, `google-gemini-api`, `groq`, `openrouter`, `xai`, `ollama`, `vllm`, `deepseek`, `mistral`, `cohere`, `zai`, `codex-cli`, `copilot-cli`
+`gemini-cli`, `anthropic`, `openai`, `google-gemini-api`, `groq`, `openrouter`, `xai`, `ollama`, `vllm`, `deepseek`, `mistral`, `cohere`, `zai`, `codex-cli`, `copilot-cli`, `qwen-cli`
 
 ### Search Pipeline -- _suggestion Post-Processing
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -1054,12 +1054,12 @@ LLM_PRIMARY=gemini-cli
 [gemini-cli] -> fail -> [anthropic] -> fail -> [codex-cli] -> fail -> [copilot-cli] -> ...
 ```
 
-**codex-cli provider** (`lib/llm/providers/codex-cli.js`):
-1. `runCodexCLI(prompt, outputFile)` -- runs `codex exec --full-auto --skip-git-repo-check -o FILE`
+**codex-cli provider** (`lib/llm/providers/CodexCliProvider.js`):
+1. `runCodexCLI(stdinContent, prompt, options)` -- runs `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE`
 2. Reads output file -> JSON parse -> return response
 - Authenticates via `OPENAI_API_KEY` or Codex CLI's own configuration file
 
-**copilot-cli provider** (`lib/llm/providers/copilot-cli.js`):
+**copilot-cli provider** (`lib/llm/providers/CopilotCliProvider.js`):
 - Calls GitHub Copilot CLI (`gh copilot suggest`) as a wrapper
 - Uses `extractJsonBlock()` utility to strip trailing statistics/banner text before JSON extraction
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -1043,20 +1043,21 @@ LocalTransformersEmbedder.generate(text)
 
 For detailed migration steps, see [docs/embedding-local.md](embedding-local.md).
 
-### LLM Dispatcher -- Codex CLI / Copilot CLI (v2.9.0)
+### LLM Dispatcher -- CLI Providers
 
-Two new providers have been added to the existing gemini-cli / openai / anthropic / ... chain.
+In the existing CLI fallback chain, `codex-cli` now carries `model` / `timeoutMs` settings through to the actual CLI call, and `qwen-cli` has been added as a new provider.
 
 ```
 LLM_PRIMARY=gemini-cli
     |
     v
-[gemini-cli] -> fail -> [anthropic] -> fail -> [codex-cli] -> fail -> [copilot-cli] -> ...
+[gemini-cli] -> fail -> [anthropic] -> fail -> [codex-cli] -> fail -> [copilot-cli] -> fail -> [qwen-cli] -> ...
 ```
 
 **codex-cli provider** (`lib/llm/providers/CodexCliProvider.js`):
 1. `runCodexCLI(stdinContent, prompt, options)` -- runs `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE`
-2. Reads output file -> JSON parse -> return response
+2. Falls back to provider-config `model` and `timeoutMs` when request options omit them
+3. Reads output file -> JSON parse -> return response
 - Authenticates via `OPENAI_API_KEY` or Codex CLI's own configuration file
 
 **copilot-cli provider** (`lib/llm/providers/CopilotCliProvider.js`):
@@ -1065,7 +1066,8 @@ LLM_PRIMARY=gemini-cli
 
 **qwen-cli provider** (`lib/llm/providers/QwenCliProvider.js`):
 - Wraps Alibaba Cloud Qwen Code CLI (`qwen`) in `--output-format text` mode
-- Extracts JSON block from text output. When `model` is omitted, the CLI default model is used
+- Extracts JSON block from text output
+- Falls back to provider-config `model` / `timeoutMs`, and uses the CLI default model only when `model` is still omitted
 - Requires `qwen auth` authentication
 
 **Circuit breaker and timeout** (`config/memory.js`):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1066,12 +1066,17 @@ LLM_PRIMARY=gemini-cli
 - GitHub Copilot CLI(`gh copilot suggest`)를 래퍼로 호출
 - `extractJsonBlock()` 유틸리티로 응답 말미의 통계/배너 텍스트 제거 후 JSON 추출
 
+**qwen-cli provider** (`lib/llm/providers/QwenCliProvider.js`):
+- Alibaba Cloud Qwen Code CLI(`qwen`)를 래퍼로 호출
+- `--output-format text` 모드로 실행 후 JSON 블록 추출
+- `model` 미지정 시 CLI 기본 모델 사용. `qwen auth` 인증 필요
+
 **circuit breaker 및 timeout** (`config/memory.js`):
 - `geminiTimeoutMs: 60000` (이전 15000에서 상향). Gemini CLI 대형 프롬프트의 지연 증가 대응
 - circuit breaker 실패 임계(LLM_CB_FAILURE_THRESHOLD=5), OPEN 지속(LLM_CB_OPEN_DURATION_MS=60000)은 기존과 동일
 
 **LLM_PRIMARY 허용값 전체 목록** (v2.9.0):
-`gemini-cli`, `anthropic`, `openai`, `google-gemini-api`, `groq`, `openrouter`, `xai`, `ollama`, `vllm`, `deepseek`, `mistral`, `cohere`, `zai`, `codex-cli`, `copilot-cli`
+`gemini-cli`, `anthropic`, `openai`, `google-gemini-api`, `groq`, `openrouter`, `xai`, `ollama`, `vllm`, `deepseek`, `mistral`, `cohere`, `zai`, `codex-cli`, `copilot-cli`, `qwen-cli`
 
 ### 검색 파이프라인 — _suggestion 후처리
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1057,12 +1057,12 @@ LLM_PRIMARY=gemini-cli
 [gemini-cli] → 실패 → [anthropic] → 실패 → [codex-cli] → 실패 → [copilot-cli] → ...
 ```
 
-**codex-cli provider** (`lib/llm/providers/codex-cli.js`):
-1. `runCodexCLI(prompt, outputFile)` — `codex exec --full-auto --skip-git-repo-check -o FILE` 실행
+**codex-cli provider** (`lib/llm/providers/CodexCliProvider.js`):
+1. `runCodexCLI(stdinContent, prompt, options)` — `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE` 실행
 2. 결과 파일 읽기 → JSON 파싱 → 응답 반환
 - 환경변수 `OPENAI_API_KEY` 또는 Codex CLI 자체 설정 파일로 인증
 
-**copilot-cli provider** (`lib/llm/providers/copilot-cli.js`):
+**copilot-cli provider** (`lib/llm/providers/CopilotCliProvider.js`):
 - GitHub Copilot CLI(`gh copilot suggest`)를 래퍼로 호출
 - `extractJsonBlock()` 유틸리티로 응답 말미의 통계/배너 텍스트 제거 후 JSON 추출
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1046,20 +1046,21 @@ LocalTransformersEmbedder.generate(text)
 
 상세 전환 절차: [docs/embedding-local.md](embedding-local.md)
 
-### LLM Dispatcher — Codex CLI / Copilot CLI (v2.9.0)
+### LLM Dispatcher — CLI Providers
 
-기존 gemini-cli / openai / anthropic / ... 체인에 두 provider가 추가되었다.
+기존 CLI fallback chain에서 `codex-cli` provider는 `model` / `timeoutMs` 설정을 실제 CLI 호출까지 전달하도록 정리되었고, `qwen-cli` provider가 새로 추가되었다.
 
 ```
 LLM_PRIMARY=gemini-cli
     │
     ▼
-[gemini-cli] → 실패 → [anthropic] → 실패 → [codex-cli] → 실패 → [copilot-cli] → ...
+[gemini-cli] → 실패 → [anthropic] → 실패 → [codex-cli] → 실패 → [copilot-cli] → 실패 → [qwen-cli] → ...
 ```
 
 **codex-cli provider** (`lib/llm/providers/CodexCliProvider.js`):
 1. `runCodexCLI(stdinContent, prompt, options)` — `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE` 실행
-2. 결과 파일 읽기 → JSON 파싱 → 응답 반환
+2. 요청 옵션이 비어 있으면 provider config의 `model`, `timeoutMs`를 fallback으로 사용
+3. 결과 파일 읽기 → JSON 파싱 → 응답 반환
 - 환경변수 `OPENAI_API_KEY` 또는 Codex CLI 자체 설정 파일로 인증
 
 **copilot-cli provider** (`lib/llm/providers/CopilotCliProvider.js`):
@@ -1069,7 +1070,8 @@ LLM_PRIMARY=gemini-cli
 **qwen-cli provider** (`lib/llm/providers/QwenCliProvider.js`):
 - Alibaba Cloud Qwen Code CLI(`qwen`)를 래퍼로 호출
 - `--output-format text` 모드로 실행 후 JSON 블록 추출
-- `model` 미지정 시 CLI 기본 모델 사용. `qwen auth` 인증 필요
+- 요청 옵션이 비어 있으면 provider config의 `model`, `timeoutMs`를 fallback으로 사용하고, `model`까지 비어 있으면 CLI 기본 모델 사용
+- `qwen auth` 인증 필요
 
 **circuit breaker 및 timeout** (`config/memory.js`):
 - `geminiTimeoutMs: 60000` (이전 15000에서 상향). Gemini CLI 대형 프롬프트의 지연 증가 대응

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -72,7 +72,7 @@ The `api_keys.symbolic_hard_gate` column (migration-033) enables per-key hard ga
 
 #### LLM Provider Fallback Chain (v2.8.0)
 
-Automatic fallback to 14 providers beyond Gemini CLI. Existing behavior is fully preserved with default settings.
+Automatic fallback to 15 providers beyond Gemini CLI. Existing behavior is fully preserved with default settings.
 
 ##### Basic Configuration
 
@@ -101,7 +101,7 @@ When REDIS_ENABLED=true, state is stored in Redis; otherwise in-memory.
 
 ##### Supported Providers
 
-gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**
+gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**, **qwen-cli**
 
 **codex-cli**: Executes `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE`. Authenticates via `OPENAI_API_KEY` or the Codex CLI config file. Specify in `LLM_FALLBACKS` as:
 ```json
@@ -111,6 +111,12 @@ gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama,
 **copilot-cli**: Wraps GitHub Copilot CLI (`gh copilot suggest`). Requires `gh` CLI and a Copilot subscription:
 ```json
 [{"provider": "copilot-cli"}]
+```
+
+**qwen-cli**: Wraps Alibaba Cloud Qwen Code CLI (`qwen`). Requires Qwen CLI authentication (`qwen auth`). When `model` is omitted, the CLI default model is used:
+```json
+[{"provider": "qwen-cli"}]
+[{"provider": "qwen-cli", "model": "qwen-max"}]
 ```
 
 **geminiTimeoutMs**: The `morphemeIndex.geminiTimeoutMs` value in `config/memory.js` has been raised from 15000ms to **60000ms**. In Gemini CLI and Ollama Cloud environments, measured response latency frequently reached 20–40s, causing repeated "all LLM providers failed" errors. This adjustment resolves that pattern.

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -72,7 +72,7 @@ The `api_keys.symbolic_hard_gate` column (migration-033) enables per-key hard ga
 
 #### LLM Provider Fallback Chain (v2.8.0)
 
-Automatic fallback to 12 providers beyond Gemini CLI. Existing behavior is fully preserved with default settings.
+Automatic fallback to 14 providers beyond Gemini CLI. Existing behavior is fully preserved with default settings.
 
 ##### Basic Configuration
 
@@ -103,9 +103,9 @@ When REDIS_ENABLED=true, state is stored in Redis; otherwise in-memory.
 
 gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**
 
-**codex-cli**: Executes `codex exec --full-auto --skip-git-repo-check -o FILE`. Authenticates via `OPENAI_API_KEY` or Codex CLI config file. Specify in `LLM_FALLBACKS` as:
+**codex-cli**: Executes `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE`. Authenticates via `OPENAI_API_KEY` or the Codex CLI config file. Specify in `LLM_FALLBACKS` as:
 ```json
-[{"provider": "codex-cli"}]
+[{"provider": "codex-cli", "model": "gpt-5.3-codex-spark"}]
 ```
 
 **copilot-cli**: Wraps GitHub Copilot CLI (`gh copilot suggest`). Requires `gh` CLI and a Copilot subscription:

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -103,7 +103,7 @@ When REDIS_ENABLED=true, state is stored in Redis; otherwise in-memory.
 
 gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**, **qwen-cli**
 
-**codex-cli**: Executes `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE`. Authenticates via `OPENAI_API_KEY` or the Codex CLI config file. Specify in `LLM_FALLBACKS` as:
+**codex-cli**: Executes `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE`. Authenticates via `OPENAI_API_KEY` or the Codex CLI config file. `model` and `timeoutMs` in `LLM_FALLBACKS` are passed through to the actual CLI invocation:
 ```json
 [{"provider": "codex-cli", "model": "gpt-5.3-codex-spark"}]
 ```
@@ -113,7 +113,7 @@ gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama,
 [{"provider": "copilot-cli"}]
 ```
 
-**qwen-cli**: Wraps Alibaba Cloud Qwen Code CLI (`qwen`). Requires Qwen CLI authentication (`qwen auth`). When `model` is omitted, the CLI default model is used:
+**qwen-cli**: Wraps Alibaba Cloud Qwen Code CLI (`qwen`). Requires Qwen CLI authentication (`qwen auth`). `model` and `timeoutMs` from `LLM_FALLBACKS` are passed through as provider config, and when `model` is still omitted the CLI default model is used:
 ```json
 [{"provider": "qwen-cli"}]
 [{"provider": "qwen-cli", "model": "qwen-max"}]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,7 +72,7 @@
 
 #### LLM Provider Fallback Chain (v2.8.0)
 
-Gemini CLI 외 14개 provider로 자동 fallback 가능. 기본값에서 기존 동작 완전 보존.
+Gemini CLI 외 15개 provider로 자동 fallback 가능. 기본값에서 기존 동작 완전 보존.
 
 ##### 기본 설정
 
@@ -101,7 +101,7 @@ REDIS_ENABLED=true면 Redis에 상태 저장, 아니면 in-memory.
 
 ##### 지원 Provider 목록
 
-gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**
+gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**, **qwen-cli**
 
 **codex-cli**: `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE` 명령을 실행한다. `OPENAI_API_KEY` 또는 Codex CLI 설정 파일로 인증한다. `LLM_FALLBACKS`에 아래와 같이 지정한다:
 ```json
@@ -111,6 +111,12 @@ gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama,
 **copilot-cli**: GitHub Copilot CLI(`gh copilot suggest`)를 래퍼로 호출한다. `gh` CLI와 Copilot 구독이 필요하다:
 ```json
 [{"provider": "copilot-cli"}]
+```
+
+**qwen-cli**: Alibaba Cloud Qwen Code CLI(`qwen`)를 래퍼로 호출한다. Qwen CLI 인증 설정(`qwen auth`)이 필요하다. `model` 미지정 시 CLI 기본 모델을 사용한다:
+```json
+[{"provider": "qwen-cli"}]
+[{"provider": "qwen-cli", "model": "qwen-max"}]
 ```
 
 **geminiTimeoutMs**: `config/memory.js`의 `morphemeIndex.geminiTimeoutMs` 값이 15000ms에서 **60000ms**로 상향되었다. Gemini CLI 및 Ollama Cloud 환경에서 실측 응답 지연이 20~40s에 달해 반복적인 "all LLM providers failed" 오류가 발생하던 문제를 해소하기 위한 조정이다.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,7 +72,7 @@
 
 #### LLM Provider Fallback Chain (v2.8.0)
 
-Gemini CLI 외 12개 provider로 자동 fallback 가능. 기본값에서 기존 동작 완전 보존.
+Gemini CLI 외 14개 provider로 자동 fallback 가능. 기본값에서 기존 동작 완전 보존.
 
 ##### 기본 설정
 
@@ -103,9 +103,9 @@ REDIS_ENABLED=true면 Redis에 상태 저장, 아니면 in-memory.
 
 gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**
 
-**codex-cli**: `codex exec --full-auto --skip-git-repo-check -o FILE` 명령을 실행한다. `OPENAI_API_KEY` 또는 Codex CLI 설정 파일로 인증한다. `LLM_FALLBACKS`에 아래와 같이 지정한다:
+**codex-cli**: `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE` 명령을 실행한다. `OPENAI_API_KEY` 또는 Codex CLI 설정 파일로 인증한다. `LLM_FALLBACKS`에 아래와 같이 지정한다:
 ```json
-[{"provider": "codex-cli"}]
+[{"provider": "codex-cli", "model": "gpt-5.3-codex-spark"}]
 ```
 
 **copilot-cli**: GitHub Copilot CLI(`gh copilot suggest`)를 래퍼로 호출한다. `gh` CLI와 Copilot 구독이 필요하다:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,7 +103,7 @@ REDIS_ENABLED=true면 Redis에 상태 저장, 아니면 in-memory.
 
 gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**, **qwen-cli**
 
-**codex-cli**: `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE` 명령을 실행한다. `OPENAI_API_KEY` 또는 Codex CLI 설정 파일로 인증한다. `LLM_FALLBACKS`에 아래와 같이 지정한다:
+**codex-cli**: `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE` 명령을 실행한다. `OPENAI_API_KEY` 또는 Codex CLI 설정 파일로 인증한다. `LLM_FALLBACKS`의 `model`, `timeoutMs` 설정이 provider config를 통해 실제 CLI 호출까지 전달된다:
 ```json
 [{"provider": "codex-cli", "model": "gpt-5.3-codex-spark"}]
 ```
@@ -113,7 +113,7 @@ gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama,
 [{"provider": "copilot-cli"}]
 ```
 
-**qwen-cli**: Alibaba Cloud Qwen Code CLI(`qwen`)를 래퍼로 호출한다. Qwen CLI 인증 설정(`qwen auth`)이 필요하다. `model` 미지정 시 CLI 기본 모델을 사용한다:
+**qwen-cli**: Alibaba Cloud Qwen Code CLI(`qwen`)를 래퍼로 호출한다. Qwen CLI 인증 설정(`qwen auth`)이 필요하다. `LLM_FALLBACKS`의 `model`, `timeoutMs` 설정을 provider config로 전달하며, `model`까지 비어 있으면 CLI 기본 모델을 사용한다:
 ```json
 [{"provider": "qwen-cli"}]
 [{"provider": "qwen-cli", "model": "qwen-max"}]

--- a/docs/operations/llm-providers.md
+++ b/docs/operations/llm-providers.md
@@ -5,7 +5,7 @@
 
 ## 개요
 
-memento-mcp는 내부 LLM 호출(AutoReflect, MorphemeIndex, ConsolidatorGC, ContradictionDetector, MemoryEvaluator)에 15개 provider fallback chain을 지원한다. 기본값은 Gemini CLI 단독 사용으로 기존 동작 완전 보존.
+memento-mcp는 내부 LLM 호출(AutoReflect, MorphemeIndex, ConsolidatorGC, ContradictionDetector, MemoryEvaluator)에 16개 provider fallback chain을 지원한다. 기본값은 Gemini CLI 단독 사용으로 기존 동작 완전 보존.
 
 ## 활성화
 
@@ -38,6 +38,7 @@ Gemini CLI 실패 시 codex-cli → anthropic → openai 순차 시도.
 | gemini-cli | - | - | - | (CLI 바이너리) |
 | codex-cli | - | 선택 | - | (CLI 바이너리 + Codex 인증) |
 | copilot-cli | - | - | - | (CLI 바이너리 + GitHub Copilot 인증) |
+| qwen-cli | - | 선택 | - | (CLI 바이너리 + Qwen 인증) |
 | anthropic | 필수 | 필수 | 선택 | https://api.anthropic.com/v1 |
 | openai | 필수 | 필수 | 선택 | https://api.openai.com/v1 |
 | google-gemini-api | 필수 | 필수 | 선택 | https://generativelanguage.googleapis.com/v1beta |

--- a/docs/operations/llm-providers.md
+++ b/docs/operations/llm-providers.md
@@ -5,7 +5,7 @@
 
 ## 개요
 
-memento-mcp는 내부 LLM 호출(AutoReflect, MorphemeIndex, ConsolidatorGC, ContradictionDetector, MemoryEvaluator)에 13개 provider fallback chain을 지원한다. 기본값은 Gemini CLI 단독 사용으로 기존 동작 완전 보존.
+memento-mcp는 내부 LLM 호출(AutoReflect, MorphemeIndex, ConsolidatorGC, ContradictionDetector, MemoryEvaluator)에 15개 provider fallback chain을 지원한다. 기본값은 Gemini CLI 단독 사용으로 기존 동작 완전 보존.
 
 ## 활성화
 
@@ -23,18 +23,21 @@ Gemini CLI만 사용. 실패 시 caller가 graceful degradation (AutoReflect ski
 ```bash
 LLM_PRIMARY=gemini-cli
 LLM_FALLBACKS='[
+  {"provider":"codex-cli","model":"gpt-5.3-codex-spark","timeoutMs":120000},
   {"provider":"anthropic","apiKey":"sk-ant-...","model":"claude-opus-4-6"},
   {"provider":"openai","apiKey":"sk-...","model":"gpt-4o-mini"}
 ]'
 ```
 
-Gemini CLI 실패 시 anthropic → openai 순차 시도.
+Gemini CLI 실패 시 codex-cli → anthropic → openai 순차 시도.
 
 ## Provider별 필수 필드
 
 | Provider | apiKey | model | baseUrl | 기본 baseUrl |
 |----------|--------|-------|---------|-------------|
 | gemini-cli | - | - | - | (CLI 바이너리) |
+| codex-cli | - | 선택 | - | (CLI 바이너리 + Codex 인증) |
+| copilot-cli | - | - | - | (CLI 바이너리 + GitHub Copilot 인증) |
 | anthropic | 필수 | 필수 | 선택 | https://api.anthropic.com/v1 |
 | openai | 필수 | 필수 | 선택 | https://api.openai.com/v1 |
 | google-gemini-api | 필수 | 필수 | 선택 | https://generativelanguage.googleapis.com/v1beta |

--- a/docs/operations/llm-providers.md
+++ b/docs/operations/llm-providers.md
@@ -30,6 +30,7 @@ LLM_FALLBACKS='[
 ```
 
 Gemini CLI 실패 시 codex-cli → anthropic → openai 순차 시도.
+CLI provider(`gemini-cli`, `codex-cli`, `copilot-cli`, `qwen-cli`)도 `LLM_FALLBACKS`의 `model`, `timeoutMs`를 provider config로 전달받는다.
 
 ## Provider별 필수 필드
 

--- a/lib/codex.js
+++ b/lib/codex.js
@@ -4,18 +4,6 @@
  * 작성자: 최진호
  * 작성일: 2026-04-18
  *
- * 정찰 결과 요약 (2026-04-18):
- *   - 바이너리: /home/nirna/.nvm/versions/node/v24.13.0/bin/codex (v0.121.0)
- *   - 핵심 플래그: codex exec --skip-git-repo-check --full-auto -o FILE [PROMPT]
- *     · --full-auto  : --sandbox workspace-write (자동 실행, 확인 없음)
- *     · --skip-git-repo-check : Git 저장소 외부에서도 실행 가능
- *     · -o FILE      : 에이전트 마지막 메시지를 파일로 기록 (파싱 타겟)
- *     · --json       : NDJSON 스트리밍 (파싱 복잡 — 사용 않음)
- *   - 테스트 호출 결과:
- *     · prompt: 'Return ONLY valid JSON...: {"status":"ok","items":["a","b"]}'
- *     · -o FILE 기록 내용: {"status":"ok","items":["a","b"]} (JSON 직접 파싱 가능)
- *   - stdin 지원: 컨텍스트를 stdin으로 주입하고 prompt 인자로 지시 분리 가능
- *
  * public API:
  *   _rawIsCodexCLIAvailable()  — CLI 바이너리 존재 여부 (CodexCliProvider 전용)
  *   isCodexCLIAvailable()      — LLM chain 가용성 위임 (llm/index.js)
@@ -81,8 +69,8 @@ export async function isCodexCLIAvailable() {
  * Codex CLI를 비대화형(exec) 모드로 호출하여 에이전트 최종 답변을 반환한다.
  *
  * 구현 전략:
- *   - `-o FILE` 플래그로 마지막 메시지만 임시 파일에 기록
- *   - `--full-auto` + `--skip-git-repo-check` 로 무인 실행
+ *   - `--output-last-message FILE` 플래그로 마지막 메시지만 임시 파일에 기록
+ *   - `--sandbox read-only` + `--skip-git-repo-check` 로 보수적 실행
  *   - 임시 파일은 try/finally 블록에서 반드시 삭제
  *   - stdinContent 제공 시 stdin으로 주입 (긴 컨텍스트 분리)
  *
@@ -100,27 +88,28 @@ export async function runCodexCLI(stdinContent, prompt, options = {}) {
   const args = [
     "exec",
     "--skip-git-repo-check",
-    "--full-auto",
-    "-o", outFile
+    "--sandbox", "read-only",
+    "--output-last-message", outFile
   ];
 
   if (options.model) {
-    args.push("-m", options.model);
+    args.push("--model", options.model);
   }
 
   args.push(prompt);
 
   return new Promise((resolve, reject) => {
     const proc = spawn("codex", args, {
-      env:   { ...process.env },
+      env:   { ...process.env, NO_COLOR: "1" },
       stdio: ["pipe", "pipe", "pipe"]
     });
 
+    let   stdout  = "";
     let   stderr  = "";
     let   settled = false;
 
     const cleanup = () => {
-      try { fs.unlinkSync(outFile); } catch (_) {}
+      try { fs.unlinkSync(outFile); } catch (_) { /* temp output already removed */ }
     };
 
     const timer = setTimeout(() => {
@@ -132,6 +121,7 @@ export async function runCodexCLI(stdinContent, prompt, options = {}) {
       }
     }, timeoutMs);
 
+    proc.stdout.on("data", (data) => { stdout += data.toString(); });
     proc.stderr.on("data", (data) => { stderr += data.toString(); });
 
     proc.on("close", (code) => {
@@ -141,7 +131,8 @@ export async function runCodexCLI(stdinContent, prompt, options = {}) {
 
       if (code !== 0) {
         cleanup();
-        reject(new Error(`Codex CLI exited with code ${code}: ${stderr.trim()}`));
+        const detail = (stderr || stdout).trim().slice(0, 1000);
+        reject(new Error(`Codex CLI exited with code ${code}: ${detail}`));
         return;
       }
 

--- a/lib/llm/providers/CodexCliProvider.js
+++ b/lib/llm/providers/CodexCliProvider.js
@@ -58,15 +58,16 @@ export class CodexCliProvider extends LlmProvider {
       throw new Error("codex-cli: circuit breaker open");
     }
 
-    /** CLI는 system role을 별도로 받지 않으므로 prompt 앞에 prepend하여 동등 효과 달성 */
-    const finalPrompt = options.systemPrompt
-      ? `${options.systemPrompt}\n\n${prompt}`
-      : prompt;
+    const finalPrompt = [
+      options.systemPrompt,
+      "Return one valid JSON value only. Do not wrap it in markdown fences. Do not add commentary before or after the JSON.",
+      prompt
+    ].filter(Boolean).join("\n\n");
 
     try {
       const raw    = await runCodexCLI("", finalPrompt, {
-        timeoutMs: options.timeoutMs || 120_000,
-        model    : options.model
+        timeoutMs: options.timeoutMs ?? this.config.timeoutMs ?? 120_000,
+        model    : options.model ?? this.config.model
       });
       const result = parseJsonResponse(raw);
       await this.recordSuccess();

--- a/lib/llm/providers/QwenCliProvider.js
+++ b/lib/llm/providers/QwenCliProvider.js
@@ -67,8 +67,7 @@ export class QwenCliProvider extends LlmProvider {
         timeoutMs: options.timeoutMs ?? this.config.timeoutMs ?? 120_000,
         model    : options.model ?? this.config.model
       });
-      const cleaned = raw.replace(/```json\s*|\s*```/g, "").trim();
-      const result  = parseJsonResponse(cleaned);
+      const result  = parseJsonResponse(raw);
       await this.recordSuccess();
       return result;
     } catch (err) {

--- a/lib/llm/providers/QwenCliProvider.js
+++ b/lib/llm/providers/QwenCliProvider.js
@@ -1,0 +1,77 @@
+/**
+ * Qwen CLI Provider (lib/qwen.js 래핑 shim)
+ *
+ * 작성자: 최진호
+ * 작성일: 2026-04-22
+ *
+ * 순환 의존성 방지 구조:
+ *   QwenCliProvider.isAvailable()  → _rawIsQwenCLIAvailable (CLI 바이너리 체크만)
+ *   QwenCliProvider.callJson()     → runQwenCLI (CLI 직접 호출)
+ *   lib/qwen.js public API         → llm/index.js (chain 전체 위임)
+ *
+ *   - callJson(): 정상 동작 (CLI 출력 → JSON 블록 추출 → parseJsonResponse)
+ *   - callText(): 미구현 — "use callJson" 에러 throw
+ */
+
+import { LlmProvider }                                from "../LlmProvider.js";
+import { parseJsonResponse }                          from "../util/parse-json.js";
+import { runQwenCLI, _rawIsQwenCLIAvailable }        from "../../qwen.js";
+
+export class QwenCliProvider extends LlmProvider {
+  constructor(config = {}) {
+    super({ ...config, name: "qwen-cli" });
+  }
+
+  /**
+   * Qwen CLI 바이너리(`qwen`) 설치 여부로 가용성을 판단한다.
+   *
+   * @returns {Promise<boolean>}
+   */
+  async isAvailable() {
+    return _rawIsQwenCLIAvailable();
+  }
+
+  /**
+   * qwen-cli는 JSON 전용이므로 callText는 미구현.
+   *
+   * @throws {Error} 항상 throw
+   */
+  async callText(_prompt, _options = {}) {
+    throw new Error("qwen-cli: use callJson (CLI returns parsed JSON)");
+  }
+
+  /**
+   * runQwenCLI를 직접 호출하여 JSON 응답을 반환한다.
+   * Circuit breaker 연동 포함.
+   *
+   * @param {string}  prompt
+   * @param {object}  [options={}]
+   * @param {number}  [options.timeoutMs=120000]
+   * @param {string}  [options.model]         - 미지정 시 Qwen CLI 기본 모델 사용
+   * @param {string}  [options.systemPrompt]  - prompt 앞에 prepend
+   * @returns {Promise<*>} 파싱된 JSON
+   */
+  async callJson(prompt, options = {}) {
+    if (await this.isCircuitOpen()) {
+      throw new Error("qwen-cli: circuit breaker open");
+    }
+
+    const finalPrompt = options.systemPrompt
+      ? `${options.systemPrompt}\n\n${prompt}`
+      : prompt;
+
+    try {
+      const raw     = await runQwenCLI("", finalPrompt, {
+        timeoutMs: options.timeoutMs || 120_000,
+        model    : options.model
+      });
+      const cleaned = raw.replace(/```json\s*|\s*```/g, "").trim();
+      const result  = parseJsonResponse(cleaned);
+      await this.recordSuccess();
+      return result;
+    } catch (err) {
+      await this.recordFailure();
+      throw err;
+    }
+  }
+}

--- a/lib/llm/providers/QwenCliProvider.js
+++ b/lib/llm/providers/QwenCliProvider.js
@@ -47,7 +47,7 @@ export class QwenCliProvider extends LlmProvider {
    * @param {string}  prompt
    * @param {object}  [options={}]
    * @param {number}  [options.timeoutMs=120000]
-   * @param {string}  [options.model]         - 미지정 시 Qwen CLI 기본 모델 사용
+   * @param {string}  [options.model]         - 미지정 시 provider config.model, 없으면 CLI 기본 모델 사용
    * @param {string}  [options.systemPrompt]  - prompt 앞에 prepend
    * @returns {Promise<*>} 파싱된 JSON
    */
@@ -56,14 +56,16 @@ export class QwenCliProvider extends LlmProvider {
       throw new Error("qwen-cli: circuit breaker open");
     }
 
-    const finalPrompt = options.systemPrompt
-      ? `${options.systemPrompt}\n\n${prompt}`
-      : prompt;
+    const finalPrompt = [
+      options.systemPrompt,
+      "Return one valid JSON value only. Do not wrap it in markdown fences. Do not add commentary before or after the JSON.",
+      prompt
+    ].filter(Boolean).join("\n\n");
 
     try {
       const raw     = await runQwenCLI("", finalPrompt, {
-        timeoutMs: options.timeoutMs || 120_000,
-        model    : options.model
+        timeoutMs: options.timeoutMs ?? this.config.timeoutMs ?? 120_000,
+        model    : options.model ?? this.config.model
       });
       const cleaned = raw.replace(/```json\s*|\s*```/g, "").trim();
       const result  = parseJsonResponse(cleaned);

--- a/lib/llm/registry.js
+++ b/lib/llm/registry.js
@@ -29,6 +29,7 @@ import { ZaiProvider }          from "./providers/ZaiProvider.js";
 import { GeminiCliProvider }    from "./providers/GeminiCliProvider.js";
 import { CodexCliProvider }     from "./providers/CodexCliProvider.js";
 import { CopilotCliProvider }   from "./providers/CopilotCliProvider.js";
+import { QwenCliProvider }      from "./providers/QwenCliProvider.js";
 
 /** Provider 이름 → 클래스 매핑 */
 const PROVIDER_CLASSES = {
@@ -46,7 +47,8 @@ const PROVIDER_CLASSES = {
   "zai"         : ZaiProvider,
   "gemini-cli"  : GeminiCliProvider,
   "codex-cli"   : CodexCliProvider,
-  "copilot-cli" : CopilotCliProvider
+  "copilot-cli" : CopilotCliProvider,
+  "qwen-cli"    : QwenCliProvider
 };
 
 /**
@@ -66,7 +68,7 @@ export function createProvider(config) {
   if (!Cls) return null;
 
   /** CLI provider는 API 키/URL 없이 로컬 바이너리 + 선택 model/timeout만 사용 */
-  if (name === "gemini-cli" || name === "codex-cli" || name === "copilot-cli") {
+  if (name === "gemini-cli" || name === "codex-cli" || name === "copilot-cli" || name === "qwen-cli") {
     return new Cls({
       model    : typeof config === "object" ? config.model ?? null : null,
       timeoutMs: typeof config === "object" ? config.timeoutMs ?? null : null

--- a/lib/llm/registry.js
+++ b/lib/llm/registry.js
@@ -65,9 +65,12 @@ export function createProvider(config) {
   const Cls = PROVIDER_CLASSES[name];
   if (!Cls) return null;
 
-  /** CLI provider는 API 키/URL 없이 바이너리만 사용 */
+  /** CLI provider는 API 키/URL 없이 로컬 바이너리 + 선택 model/timeout만 사용 */
   if (name === "gemini-cli" || name === "codex-cli" || name === "copilot-cli") {
-    return new Cls({});
+    return new Cls({
+      model    : typeof config === "object" ? config.model ?? null : null,
+      timeoutMs: typeof config === "object" ? config.timeoutMs ?? null : null
+    });
   }
 
   return new Cls({

--- a/lib/qwen.js
+++ b/lib/qwen.js
@@ -1,0 +1,142 @@
+/**
+ * Qwen CLI Client (memento-mcp 전용)
+ *
+ * 작성자: 최진호
+ * 작성일: 2026-04-22
+ *
+ * public API:
+ *   _rawIsQwenCLIAvailable()  — CLI 바이너리 존재 여부 (QwenCliProvider 전용)
+ *   isQwenCLIAvailable()      — LLM chain 가용성 위임 (llm/index.js)
+ *   qwenCLIJson()             — LLM chain JSON 호출 위임 (llm/index.js)
+ *   runQwenCLI()              — CLI 저수준 호출 (QwenCliProvider 전용)
+ *
+ * 순환 의존성 방지:
+ *   lib/qwen.js → lib/llm/index.js (동적 import, public API에서만)
+ *   lib/qwen.js는 lib/llm/index.js를 정적 import하지 않는다.
+ */
+
+import { spawn } from "child_process";
+
+// ---------------------------------------------------------------------------
+// 내부 전용: 실제 CLI 바이너리 존재 여부 확인
+// QwenCliProvider.isAvailable()에서 호출한다.
+// ---------------------------------------------------------------------------
+
+let _qwenCLICached = null;
+
+/**
+ * Qwen CLI 바이너리(`qwen`) 설치 여부를 확인한다.
+ * QwenCliProvider 내부 전용 — 일반 호출부에서 직접 사용하지 말 것.
+ *
+ * @returns {Promise<boolean>}
+ */
+export async function _rawIsQwenCLIAvailable() {
+  if (_qwenCLICached !== null) return _qwenCLICached;
+  try {
+    const { execSync } = await import("child_process");
+    execSync("which qwen", { stdio: "ignore", timeout: 5000 });
+    _qwenCLICached = true;
+  } catch {
+    _qwenCLICached = false;
+  }
+  return _qwenCLICached;
+}
+
+// ---------------------------------------------------------------------------
+// Public API (thin shim → llm/index.js 위임)
+// ---------------------------------------------------------------------------
+
+/**
+ * LLM chain에 사용 가능한 provider가 있는지 확인한다.
+ *
+ * @returns {Promise<boolean>}
+ */
+export async function isQwenCLIAvailable() {
+  const { isLlmAvailable } = await import("./llm/index.js");
+  return isLlmAvailable();
+}
+
+/**
+ * LLM chain을 통해 JSON 응답을 생성한다.
+ *
+ * @param {string} prompt   - JSON 응답을 요구하는 프롬프트
+ * @param {Object} options  - { timeoutMs, model }
+ * @returns {Promise<Object>} 파싱된 JSON 객체
+ */
+export async function qwenCLIJson(prompt, options = {}) {
+  const { llmJson } = await import("./llm/index.js");
+  return llmJson(prompt, options);
+}
+
+// ---------------------------------------------------------------------------
+// 저수준 CLI 호출 — QwenCliProvider 전용
+// ---------------------------------------------------------------------------
+
+/**
+ * Qwen CLI로 텍스트 생성 (stdin 컨텍스트 + positional 프롬프트)
+ *
+ * 실행 contract:
+ *   qwen PROMPT --output-format text [-m MODEL]
+ *   - model 미지정 시 Qwen CLI 기본 모델 사용
+ *   - stdin 입력은 --input-format text(기본값)로 자동 처리
+ *
+ * @param {string} stdinContent - stdin으로 전달할 컨텍스트 (빈 문자열이면 주입 없음)
+ * @param {string} prompt       - positional 인자로 전달할 지시 프롬프트
+ * @param {Object} [options={}]
+ * @param {number} [options.timeoutMs=120000] - 프로세스 타임아웃 (ms)
+ * @param {string} [options.model]            - 사용할 모델명 (-m 플래그, 없으면 CLI 기본값)
+ * @returns {Promise<string>} Qwen CLI 출력 텍스트
+ */
+export async function runQwenCLI(stdinContent, prompt, options = {}) {
+  const timeoutMs = options.timeoutMs || 120_000;
+
+  return new Promise((resolve, reject) => {
+    const args = ["--output-format", "text"];
+    if (options.model) args.push("-m", options.model);
+    args.push(prompt);
+
+    const proc = spawn("qwen", args, {
+      env:   { ...process.env },
+      stdio: ["pipe", "pipe", "pipe"]
+    });
+
+    let stdout  = "";
+    let stderr  = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        proc.kill("SIGTERM");
+        reject(new Error(`Qwen CLI timed out after ${timeoutMs}ms`));
+      }
+    }, timeoutMs);
+
+    proc.stdout.on("data", (data) => { stdout += data.toString(); });
+    proc.stderr.on("data", (data) => { stderr += data.toString(); });
+
+    proc.on("close", (code) => {
+      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
+      if (code !== 0) {
+        reject(new Error(`Qwen CLI exited with code ${code}: ${stderr.trim()}`));
+      } else {
+        resolve(stdout.trim());
+      }
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timer);
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Qwen CLI spawn error: ${err.message}`));
+      }
+    });
+
+    if (stdinContent) {
+      proc.stdin.write(stdinContent, "utf8");
+    }
+    proc.stdin.end();
+  });
+}

--- a/tests/unit/codex-cli-provider.test.js
+++ b/tests/unit/codex-cli-provider.test.js
@@ -1,230 +1,118 @@
 /**
  * Unit tests: CodexCliProvider
  *
- * 실제 Codex CLI 호출 0건 — runCodexCLI와 _rawIsCodexCLIAvailable을 mock으로 교체.
- * circuit breaker 상태는 테스트마다 recordSuccess로 초기화하여 격리한다.
- *
- * 작성자: 최진호
- * 작성일: 2026-04-18
+ * 실제 codex 바이너리 호출 0건 — lib/codex.js를 mock.module로 차단한다.
  */
 
-import { describe, it, before, afterEach } from "node:test";
-import assert                               from "node:assert/strict";
+import { beforeEach, describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
 
-// ---------------------------------------------------------------------------
-// module-level mock 주입: node:test는 jest.mock 같은 자동 호이스팅이 없으므로
-// 테스트 내에서 동적으로 교체할 수 있도록 wrapper를 준비한다.
-// ---------------------------------------------------------------------------
+const mockRunCodexCLI   = mock.fn();
+const mockRawIsCodexCli = mock.fn();
 
-import * as codexModule from "../../lib/codex.js";
-
-let _isAvailableImpl = async () => true;
-let _runCodexImpl    = async () => '{"result":"ok"}';
-
-/** mock shim: _rawIsCodexCLIAvailable 교체 */
-function mockAvailable(impl) { _isAvailableImpl = impl; }
-/** mock shim: runCodexCLI 교체 */
-function mockRunCodex(impl)  { _runCodexImpl    = impl; }
-/** 기본값 복구 */
-function resetMocks() {
-  _isAvailableImpl = async () => true;
-  _runCodexImpl    = async () => '{"result":"ok"}';
-}
-
-// CodexCliProvider가 codexModule 함수를 직접 호출하므로
-// prototype-level patch를 통해 provider 동작을 제어한다.
-
-import { CodexCliProvider } from "../../lib/llm/providers/CodexCliProvider.js";
-
-const _origIsAvailable = codexModule._rawIsCodexCLIAvailable;
-const _origRunCodex    = codexModule.runCodexCLI;
-
-// node:test에서는 import가 live binding이 아니므로
-// provider 인스턴스 메서드를 직접 패치하는 방식으로 mock한다.
-
-function makeProvider() {
-  const p = new CodexCliProvider();
-  /** isAvailable: _rawIsCodexCLIAvailable 결과를 _isAvailableImpl로 대체 */
-  p.isAvailable = async () => _isAvailableImpl();
-  /** callJson 내부 runCodexCLI를 패치하기 위해 callJson을 래핑 */
-  const _origCallJson = p.callJson.bind(p);
-  p.callJson = async (prompt, options = {}) => {
-    const savedRunCodex = codexModule.runCodexCLI;
-    // 인스턴스 수준에서 callJson 재구현 (runCodexCLI mock 주입)
-    if (await p.isCircuitOpen()) {
-      throw new Error("codex-cli: circuit breaker open");
-    }
-    const finalPrompt = options.systemPrompt
-      ? `${options.systemPrompt}\n\n${prompt}`
-      : prompt;
-    try {
-      const raw    = await _runCodexImpl("", finalPrompt, options);
-      const { parseJsonResponse } = await import("../../lib/llm/util/parse-json.js");
-      const result = parseJsonResponse(raw);
-      await p.recordSuccess();
-      return result;
-    } catch (err) {
-      await p.recordFailure();
-      throw err;
-    }
-  };
-  return p;
-}
-
-import { circuitBreaker } from "../../lib/llm/util/circuit-breaker.js";
-import { redisClient }    from "../../lib/redis.js";
-
-import { after } from "node:test";
-after(async () => {
-  try { await redisClient.quit(); } catch (_) {}
+mock.module("../../lib/codex.js", {
+  exports: {
+    runCodexCLI            : (...args) => mockRunCodexCLI(...args),
+    _rawIsCodexCLIAvailable: (...args) => mockRawIsCodexCli(...args)
+  }
 });
 
-// ---------------------------------------------------------------------------
-// 테스트
-// ---------------------------------------------------------------------------
+const { CodexCliProvider } = await import("../../lib/llm/providers/CodexCliProvider.js");
+const { createProvider, listProviderNames } = await import("../../lib/llm/registry.js");
 
 describe("CodexCliProvider", () => {
-
-  afterEach(() => {
-    resetMocks();
+  beforeEach(() => {
+    mockRunCodexCLI.mock.resetCalls();
+    mockRawIsCodexCli.mock.resetCalls();
   });
 
-  // -------------------------------------------------------------------------
-  // isAvailable
-  // -------------------------------------------------------------------------
-
-  describe("isAvailable", () => {
-
-    it("codex 바이너리가 존재하면 true를 반환한다", async () => {
-      mockAvailable(async () => true);
-      const p = makeProvider();
-      assert.equal(await p.isAvailable(), true);
-    });
-
-    it("codex 바이너리가 없으면 false를 반환한다", async () => {
-      mockAvailable(async () => false);
-      const p = makeProvider();
-      assert.equal(await p.isAvailable(), false);
-    });
-
+  it("isAvailable: raw helper 결과를 그대로 반환한다", async () => {
+    mockRawIsCodexCli.mock.mockImplementationOnce(async () => true);
+    const provider = new CodexCliProvider();
+    assert.equal(await provider.isAvailable(), true);
   });
 
-  // -------------------------------------------------------------------------
-  // callText
-  // -------------------------------------------------------------------------
+  it("callText: JSON 전용 provider이므로 use callJson 에러를 던진다", async () => {
+    const provider = new CodexCliProvider();
 
-  describe("callText", () => {
-
-    it("항상 'use callJson' 에러를 던진다", async () => {
-      const p = new CodexCliProvider();
-      await assert.rejects(
-        () => p.callText("any prompt"),
-        /use callJson/
-      );
-    });
-
+    await assert.rejects(
+      () => provider.callText("hello"),
+      /use callJson/
+    );
   });
 
-  // -------------------------------------------------------------------------
-  // callJson — 성공
-  // -------------------------------------------------------------------------
-
-  describe("callJson - 성공", () => {
-
-    it("runCodexCLI가 JSON 문자열을 반환하면 파싱된 객체를 반환한다", async () => {
-      mockRunCodex(async () => '{"result":"ok","score":42}');
-      const p    = makeProvider();
-      const json = await p.callJson("test prompt");
-      assert.deepEqual(json, { result: "ok", score: 42 });
+  it("callJson: systemPrompt + JSON-only 가이드 + prompt를 helper로 전달한다", async () => {
+    mockRunCodexCLI.mock.mockImplementationOnce(async (stdinContent, prompt, options) => {
+      assert.equal(stdinContent, "");
+      assert.ok(prompt.includes("system rules"));
+      assert.ok(prompt.includes("Return one valid JSON value only."));
+      assert.ok(prompt.includes("user payload"));
+      assert.equal(options.model, "gpt-5.3-codex-spark");
+      assert.equal(options.timeoutMs, 1234);
+      return "{\"ok\":true,\"source\":\"codex-cli\"}";
     });
 
-    it("runCodexCLI가 markdown 펜스 감싼 JSON을 반환해도 파싱한다", async () => {
-      mockRunCodex(async () => "```json\n{\"key\":\"val\"}\n```");
-      const p    = makeProvider();
-      const json = await p.callJson("test prompt");
-      assert.deepEqual(json, { key: "val" });
+    const provider = new CodexCliProvider({ model: "default-model" });
+    const result = await provider.callJson("user payload", {
+      systemPrompt: "system rules",
+      model       : "gpt-5.3-codex-spark",
+      timeoutMs   : 1234
     });
 
-    it("systemPrompt가 있으면 prompt 앞에 prepend하여 호출한다", async () => {
-      let capturedPrompt = "";
-      mockRunCodex(async (_stdin, finalPrompt) => {
-        capturedPrompt = finalPrompt;
-        return '{"ok":true}';
-      });
-      const p = makeProvider();
-      await p.callJson("actual prompt", { systemPrompt: "SYSTEM" });
-      assert.match(capturedPrompt, /SYSTEM/);
-      assert.match(capturedPrompt, /actual prompt/);
-    });
-
+    assert.deepEqual(result, { ok: true, source: "codex-cli" });
   });
 
-  // -------------------------------------------------------------------------
-  // callJson — 실패
-  // -------------------------------------------------------------------------
-
-  describe("callJson - 실패", () => {
-
-    it("runCodexCLI가 throw하면 recordFailure를 호출하고 에러를 전파한다", async () => {
-      mockRunCodex(async () => { throw new Error("CLI failed"); });
-
-      const p              = makeProvider();
-      let   failureRecorded = false;
-      const _origRecord    = p.recordFailure.bind(p);
-      p.recordFailure      = async () => { failureRecorded = true; return _origRecord(); };
-
-      await assert.rejects(
-        () => p.callJson("test prompt"),
-        /CLI failed/
-      );
-      assert.equal(failureRecorded, true);
+  it("callJson: options.model이 없으면 provider config.model을 사용한다", async () => {
+    mockRunCodexCLI.mock.mockImplementationOnce(async (_stdinContent, _prompt, options) => {
+      assert.equal(options.model, "gpt-5.3-codex-spark");
+      return "{\"ok\":true}";
     });
 
-    it("runCodexCLI가 파싱 불가능한 문자열을 반환하면 에러를 던진다", async () => {
-      mockRunCodex(async () => "not json at all");
-      const p = makeProvider();
-      await assert.rejects(
-        () => p.callJson("test prompt"),
-        /failed to parse JSON/
-      );
-    });
+    const provider = new CodexCliProvider({ model: "gpt-5.3-codex-spark" });
+    const result = await provider.callJson("user payload");
 
+    assert.deepEqual(result, { ok: true });
   });
 
-  // -------------------------------------------------------------------------
-  // circuit breaker
-  // -------------------------------------------------------------------------
-
-  describe("circuit breaker", () => {
-
-    it("circuit이 열려 있으면 runCodexCLI를 호출하지 않고 에러를 던진다", async () => {
-      let runCodexCalled = false;
-      mockRunCodex(async () => { runCodexCalled = true; return '{"ok":true}'; });
-
-      const p = makeProvider();
-
-      /** circuit을 강제로 open 상태로 만든다 */
-      const _origIsCircuitOpen = p.isCircuitOpen.bind(p);
-      p.isCircuitOpen = async () => true;
-
-      await assert.rejects(
-        () => p.callJson("test prompt"),
-        /circuit breaker open/
-      );
-      assert.equal(runCodexCalled, false);
+  it("callJson: options.timeoutMs이 없으면 provider config.timeoutMs를 사용한다", async () => {
+    mockRunCodexCLI.mock.mockImplementationOnce(async (_stdinContent, _prompt, options) => {
+      assert.equal(options.timeoutMs, 2222);
+      return "{\"ok\":true}";
     });
 
-    it("circuit이 닫혀 있으면 runCodexCLI를 호출한다", async () => {
-      let runCodexCalled = false;
-      mockRunCodex(async () => { runCodexCalled = true; return '{"ok":true}'; });
+    const provider = new CodexCliProvider({ timeoutMs: 2222 });
+    const result = await provider.callJson("user payload");
 
-      const p = makeProvider();
-      p.isCircuitOpen = async () => false;
-
-      await p.callJson("test prompt");
-      assert.equal(runCodexCalled, true);
-    });
-
+    assert.deepEqual(result, { ok: true });
   });
 
+  it("callJson: circuit breaker open 상태면 helper 호출 없이 에러를 던진다", async () => {
+    const provider = new CodexCliProvider();
+    provider.isCircuitOpen = async () => true;
+
+    await assert.rejects(
+      () => provider.callJson("user payload"),
+      /circuit breaker open/
+    );
+
+    assert.equal(mockRunCodexCLI.mock.callCount(), 0);
+  });
+});
+
+describe("codex-cli registry wiring", () => {
+  it("listProviderNames: codex-cli를 노출한다", () => {
+    assert.ok(listProviderNames().includes("codex-cli"));
+  });
+
+  it("createProvider: codex-cli config로 provider 인스턴스를 생성한다", () => {
+    const provider = createProvider({
+      provider : "codex-cli",
+      model    : "gpt-5.3-codex-spark",
+      timeoutMs: 2222
+    });
+
+    assert.equal(provider?.name, "codex-cli");
+    assert.equal(provider?.config?.model, "gpt-5.3-codex-spark");
+    assert.equal(provider?.config?.timeoutMs, 2222);
+  });
 });

--- a/tests/unit/qwen-cli-provider.test.js
+++ b/tests/unit/qwen-cli-provider.test.js
@@ -95,6 +95,15 @@ describe("QwenCliProvider", () => {
     assert.deepEqual(result, { ok: true });
   });
 
+  it("callJson: JSON 문자열 내부의 triple backticks를 보존한다", async () => {
+    mockRunQwenCLI.mock.mockImplementationOnce(async () => "```json\n{\"snippet\":\"```ts\\nconst ok = true;\\n```\"}\n```");
+
+    const provider = new QwenCliProvider();
+    const result = await provider.callJson("user payload");
+
+    assert.deepEqual(result, { snippet: "```ts\nconst ok = true;\n```" });
+  });
+
   it("callJson: circuit breaker open 상태면 helper 호출 없이 에러를 던진다", async () => {
     const provider = new QwenCliProvider();
     provider.isCircuitOpen = async () => true;

--- a/tests/unit/qwen-cli-provider.test.js
+++ b/tests/unit/qwen-cli-provider.test.js
@@ -1,0 +1,127 @@
+/**
+ * Unit tests: QwenCliProvider
+ *
+ * 실제 qwen 바이너리 호출 0건 — lib/qwen.js를 mock.module로 차단한다.
+ */
+
+import { beforeEach, describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+const mockRunQwenCLI   = mock.fn();
+const mockRawIsQwenCli = mock.fn();
+
+mock.module("../../lib/qwen.js", {
+  exports: {
+    runQwenCLI            : (...args) => mockRunQwenCLI(...args),
+    _rawIsQwenCLIAvailable: (...args) => mockRawIsQwenCli(...args)
+  }
+});
+
+const { QwenCliProvider } = await import("../../lib/llm/providers/QwenCliProvider.js");
+const { createProvider, listProviderNames } = await import("../../lib/llm/registry.js");
+
+describe("QwenCliProvider", () => {
+  beforeEach(() => {
+    mockRunQwenCLI.mock.resetCalls();
+    mockRawIsQwenCli.mock.resetCalls();
+  });
+
+  it("isAvailable: raw helper 결과를 그대로 반환한다", async () => {
+    mockRawIsQwenCli.mock.mockImplementationOnce(async () => true);
+    const provider = new QwenCliProvider();
+    assert.equal(await provider.isAvailable(), true);
+  });
+
+  it("callText: JSON 전용 provider이므로 use callJson 에러를 던진다", async () => {
+    const provider = new QwenCliProvider();
+
+    await assert.rejects(
+      () => provider.callText("hello"),
+      /use callJson/
+    );
+  });
+
+  it("callJson: systemPrompt + JSON-only 가이드 + prompt를 helper로 전달한다", async () => {
+    mockRunQwenCLI.mock.mockImplementationOnce(async (stdinContent, prompt, options) => {
+      assert.equal(stdinContent, "");
+      assert.ok(prompt.includes("system rules"));
+      assert.ok(prompt.includes("Return one valid JSON value only."));
+      assert.ok(prompt.includes("user payload"));
+      assert.equal(options.model, "qwen-max");
+      assert.equal(options.timeoutMs, 3456);
+      return "{\"ok\":true,\"source\":\"qwen-cli\"}";
+    });
+
+    const provider = new QwenCliProvider({ model: "default-model" });
+    const result = await provider.callJson("user payload", {
+      systemPrompt: "system rules",
+      model       : "qwen-max",
+      timeoutMs   : 3456
+    });
+
+    assert.deepEqual(result, { ok: true, source: "qwen-cli" });
+  });
+
+  it("callJson: options.model이 없으면 provider config.model을 사용한다", async () => {
+    mockRunQwenCLI.mock.mockImplementationOnce(async (_stdinContent, _prompt, options) => {
+      assert.equal(options.model, "qwen-max");
+      return "{\"ok\":true}";
+    });
+
+    const provider = new QwenCliProvider({ model: "qwen-max" });
+    const result = await provider.callJson("user payload");
+
+    assert.deepEqual(result, { ok: true });
+  });
+
+  it("callJson: options.timeoutMs이 없으면 provider config.timeoutMs를 사용한다", async () => {
+    mockRunQwenCLI.mock.mockImplementationOnce(async (_stdinContent, _prompt, options) => {
+      assert.equal(options.timeoutMs, 2222);
+      return "{\"ok\":true}";
+    });
+
+    const provider = new QwenCliProvider({ timeoutMs: 2222 });
+    const result = await provider.callJson("user payload");
+
+    assert.deepEqual(result, { ok: true });
+  });
+
+  it("callJson: fenced JSON 출력도 파싱한다", async () => {
+    mockRunQwenCLI.mock.mockImplementationOnce(async () => "```json\n{\"ok\":true}\n```");
+
+    const provider = new QwenCliProvider();
+    const result = await provider.callJson("user payload");
+
+    assert.deepEqual(result, { ok: true });
+  });
+
+  it("callJson: circuit breaker open 상태면 helper 호출 없이 에러를 던진다", async () => {
+    const provider = new QwenCliProvider();
+    provider.isCircuitOpen = async () => true;
+
+    await assert.rejects(
+      () => provider.callJson("user payload"),
+      /circuit breaker open/
+    );
+
+    assert.equal(mockRunQwenCLI.mock.callCount(), 0);
+  });
+});
+
+describe("qwen-cli registry wiring", () => {
+  it("listProviderNames: qwen-cli를 노출한다", () => {
+    assert.ok(listProviderNames().includes("qwen-cli"));
+  });
+
+  it("createProvider: qwen-cli config로 provider 인스턴스를 생성한다", () => {
+    const provider = createProvider({
+      provider : "qwen-cli",
+      model    : "qwen-max",
+      timeoutMs: 2222
+    });
+
+    assert.equal(provider?.name, "qwen-cli");
+    assert.equal(provider?.config?.model, "qwen-max");
+    assert.equal(provider?.config?.timeoutMs, 2222);
+  });
+});


### PR DESCRIPTION
## 목표
- 기존 `codex-cli` provider가 `LLM_PRIMARY` / `LLM_FALLBACKS`의 `model`, `timeoutMs` 설정을 실제 CLI 호출까지 반영하도록 정리하고, `qwen-cli` provider를 fallback chain에 추가합니다.
- `codex-cli` 실행 contract와 관련 문서를 현재 CLI surface에 맞추고, 문서 서술을 `codex 추가`가 아니라 `codex 보강 + qwen 추가` 기준으로 맞춥니다.

## 해결한 내용
- `lib/llm/registry.js`
  - CLI provider 생성 시 `model`, `timeoutMs`를 provider config로 전달하도록 정리하고, `qwen-cli` 매핑을 추가했습니다.
- `lib/llm/providers/CodexCliProvider.js`, `lib/codex.js`
  - `codex-cli`가 provider config의 `model`, `timeoutMs`를 실제 CLI 호출에 반영하도록 보강하고, `codex exec` 호출 contract를 현재 CLI surface에 맞췄습니다.
- `lib/qwen.js`, `lib/llm/providers/QwenCliProvider.js`
  - `qwen-cli` 저수준 래퍼와 provider shim을 추가했습니다.
  - `QwenCliProvider`도 provider config의 `model`, `timeoutMs`를 fallback으로 사용하고, fenced JSON 내부 문자열을 훼손하지 않도록 `parseJsonResponse(raw)` 경로로 정리했습니다.
- `tests/unit/codex-cli-provider.test.js`, `tests/unit/qwen-cli-provider.test.js`
  - `codex-cli` / `qwen-cli` provider의 config fallback, registry wiring, JSON parsing contract를 검증하는 단위 테스트를 추가/보강했습니다.
  - `qwen-cli`의 triple-backtick 문자열 보존 회귀 테스트를 추가했습니다.
- `docs/configuration.md`, `docs/configuration.en.md`, `docs/operations/llm-providers.md`, `docs/architecture.md`, `docs/architecture.en.md`
  - `codex-cli`는 이미 upstream에 존재한다는 전제에서 문서를 `config 전달 보강` 중심으로 정리하고, `qwen-cli` 사용 예시와 fallback semantics를 반영했습니다.

## 검증
- `node --experimental-test-module-mocks --test tests/unit/qwen-cli-provider.test.js tests/unit/codex-cli-provider.test.js tests/unit/llm-fallback-chain.test.js`
  - `codex-cli` / `qwen-cli` provider contract와 fallback chain 회귀를 확인했습니다.
- `npx eslint lib/llm/providers/QwenCliProvider.js tests/unit/qwen-cli-provider.test.js`
  - 마지막 수정 범위 lint를 확인했습니다.
- `node --input-type=module`
  - `lib/codex.js`의 `runCodexCLI()` 경로 E2E 스모크에서 `{"ok":true}` 반환을 확인했습니다.
- `node --input-type=module`
  - `QwenCliProvider` 기본 설정 E2E 스모크에서 `{"ok":true,"provider":"qwen-cli","mode":"default"}` 반환을 확인했습니다.
- `node --input-type=module`
  - `QwenCliProvider({ model: "qwen-max" })` 경로 E2E 스모크에서 `{"ok":true,"provider":"qwen-cli","mode":"provider-config"}` 반환을 확인했습니다.

## 포트 메모
- `codex-cli provider 추가`라는 표현은 `v3.0.0` 기준 upstream에 이미 provider 자체가 포함된 상태라 제거했습니다.
- 이번 PR 범위는 `codex-cli` 설정 전달 / 실행 contract 보강과 `qwen-cli` provider 추가로 정리했습니다.
