### PR TITLE
Control Memento runtime memory on Windows

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -292,6 +292,7 @@ export const LLM_TOKEN_BUDGET_WINDOW_SEC = Number(process.env.LLM_TOKEN_BUDGET_W
 /** NLI 서비스 설정 (미설정 시 in-process ONNX 모델 로드) */
 export const NLI_SERVICE_URL    = process.env.NLI_SERVICE_URL || "";
 export const NLI_TIMEOUT_MS     = Number(process.env.NLI_TIMEOUT_MS || 5000);
+export const INPROCESS_ONNX_ENABLED = process.env.MEMENTO_INPROCESS_ONNX_ENABLED !== "false";
 
 /**
  * Case event 검증 결과(verification_passed/failed)를 증거 파편 importance에 역전파할지 여부.

--- a/lib/memory/LinkStore.js
+++ b/lib/memory/LinkStore.js
@@ -138,8 +138,7 @@ export class LinkStore {
         VALUES ${valueClauses.join(", ")}
         ON CONFLICT (from_id, to_id) DO UPDATE
           SET relation_type = EXCLUDED.relation_type,
-              weight        = GREATEST(${SCHEMA}.fragment_links.weight, EXCLUDED.weight),
-              accessed_at   = NOW()
+              weight        = GREATEST(${SCHEMA}.fragment_links.weight, EXCLUDED.weight)
         RETURNING id`;
 
       const result = await client.query(insertSql, params);

--- a/lib/memory/Reranker.js
+++ b/lib/memory/Reranker.js
@@ -17,11 +17,16 @@
  *   - cross-encoder: [query, document] 쌍으로 relevance score 출력
  */
 
-import { RERANKER_URL, RERANKER_TIMEOUT_MS, RERANKER_MODEL } from "../config.js";
+import {
+  INPROCESS_ONNX_ENABLED,
+  RERANKER_MODEL,
+  RERANKER_TIMEOUT_MS,
+  RERANKER_URL
+} from "../config.js";
 import { logInfo, logWarn } from "../logger.js";
 
 /** ─── 공유 상태 ─── */
-let _mode                      = RERANKER_URL ? "external" : "inprocess";
+let _mode                      = RERANKER_URL ? "external" : (INPROCESS_ONNX_ENABLED ? "inprocess" : "disabled");
 let _failed                    = false;
 let _consecutiveExternalFails  = 0;
 const EXTERNAL_FAIL_THRESHOLD  = 3;
@@ -173,6 +178,7 @@ async function rerankInProcess(query, documents) {
  * 임계치 초과 시 rerank() 내부에서 inprocess로 자동 전환된다.
  */
 export function isRerankerAvailable() {
+  if (_mode === "disabled") return false;
   if (_mode === "external") return _consecutiveExternalFails < EXTERNAL_FAIL_THRESHOLD;
   return !_failed;
 }
@@ -216,17 +222,20 @@ export async function rerank(query, candidates, topK = 15) {
   /** 모드별 점수 산출 */
   const scores = _mode === "external"
     ? await rerankExternal(query, documents)
-    : await rerankInProcess(query, documents);
+    : (_mode === "inprocess" ? await rerankInProcess(query, documents) : null);
 
   /** 서비스 불가 시 graceful degradation: 원본 그대로 반환 */
   if (!scores) {
     if (_mode === "external") {
       _consecutiveExternalFails++;
-      if (_consecutiveExternalFails >= EXTERNAL_FAIL_THRESHOLD) {
+      if (_consecutiveExternalFails >= EXTERNAL_FAIL_THRESHOLD && INPROCESS_ONNX_ENABLED) {
         logWarn("[Reranker] External service unavailable (3 consecutive failures), switching to in-process mode");
         _mode = "inprocess";
         _consecutiveExternalFails = 0;
         loadModel().catch(() => {});
+      } else if (_consecutiveExternalFails >= EXTERNAL_FAIL_THRESHOLD) {
+        logWarn("[Reranker] External service unavailable and in-process ONNX is disabled; reranking disabled");
+        _mode = "disabled";
       }
     }
     return candidates;
@@ -256,10 +265,20 @@ export async function preloadReranker() {
       const data = await res.json();
       logInfo(`[Reranker] External mode: ${RERANKER_URL} (model: ${data.model || "unknown"})`);
     } catch (err) {
-      logWarn(`[Reranker] External service health check failed: ${err.message}, falling back to in-process`);
-      _mode = "inprocess";
-      await loadModel();
+      if (INPROCESS_ONNX_ENABLED) {
+        logWarn(`[Reranker] External service health check failed: ${err.message}, falling back to in-process`);
+        _mode = "inprocess";
+        await loadModel();
+      } else {
+        logWarn(`[Reranker] External service health check failed: ${err.message}; in-process ONNX disabled`);
+        _mode = "disabled";
+      }
     }
+    return;
+  }
+
+  if (_mode === "disabled") {
+    logInfo("[Reranker] In-process ONNX disabled by MEMENTO_INPROCESS_ONNX_ENABLED=false");
     return;
   }
 

--- a/lib/memory/SearchParamAdaptor.js
+++ b/lib/memory/SearchParamAdaptor.js
@@ -26,6 +26,9 @@ const CLAMP_MAX   = 0.60;
 const DEFAULT_SIM = MEMORY_CONFIG.semanticSearch?.minSimilarity ?? 0.35;
 
 const _normalizeKeyId = (keyId) => normalizeKeyId(keyId, { mode: 'search' });
+const isAdaptorEnabled = () => !["0", "false", "off", "no"].includes(
+  String(process.env.MEMENTO_SEARCH_PARAM_ADAPTOR_ENABLED ?? "true").trim().toLowerCase()
+);
 
 export class SearchParamAdaptor {
   /**
@@ -36,6 +39,10 @@ export class SearchParamAdaptor {
     /** 옵트인 ENV: MEMENTO_RECALL_MIN_SIM_FLOOR가 설정되면 adaptor 학습값과 무관하게 하한을 강제한다. */
     const floorRaw  = Number(process.env.MEMENTO_RECALL_MIN_SIM_FLOOR);
     const applyFloor = (v) => Number.isFinite(floorRaw) ? Math.max(floorRaw, v) : v;
+
+    if (!isAdaptorEnabled()) {
+      return applyFloor(DEFAULT_SIM);
+    }
 
     try {
       const pool = getPrimaryPool();
@@ -69,6 +76,10 @@ export class SearchParamAdaptor {
    * fire-and-forget -- SELECT 없이 단일 UPSERT로 원자적 처리.
    */
   async recordOutcome(keyId, queryType, hour, resultCount) {
+    if (!isAdaptorEnabled()) {
+      return;
+    }
+
     try {
       const pool = getPrimaryPool();
       if (!pool) return;

--- a/lib/memory/assistant-query.js
+++ b/lib/memory/assistant-query.js
@@ -84,7 +84,7 @@ export function expandAssistantQuery(text) {
  * 어시스턴트 발화 파편이 상위에 노출되도록 한다.
  *
  * @param {Object[]} fragments - 검색 결과 파편 배열
- * @param {number}   boost     - 부스트 값 (기본 0.05)
+ * @param {number}   boost     - 부스트 값 (기본 0.02)
  * @returns {Object[]} 부스트 적용된 파편 배열 (원본 변경)
  */
 export function boostAssistantFragments(fragments, boost = 0.02) {

--- a/lib/memory/signals/NLIClassifier.js
+++ b/lib/memory/signals/NLIClassifier.js
@@ -22,11 +22,11 @@
  *   3. Gemini CLI 에스컬레이션 → 수치/도메인 모순 처리
  */
 
-import { NLI_SERVICE_URL, NLI_TIMEOUT_MS } from "../../config.js";
+import { INPROCESS_ONNX_ENABLED, NLI_SERVICE_URL, NLI_TIMEOUT_MS } from "../../config.js";
 import { logInfo, logWarn } from "../../logger.js";
 
 /** ─── 공유 상태 ─── */
-let _mode    = NLI_SERVICE_URL ? "external" : "inprocess";
+let _mode    = NLI_SERVICE_URL ? "external" : (INPROCESS_ONNX_ENABLED ? "inprocess" : "disabled");
 let _failed  = false;
 
 /** ─── In-Process 전용 상태 ─── */
@@ -179,6 +179,7 @@ async function classifyInProcess(premise, hypothesis) {
  * NLI 모델 사용 가능 여부 (동기)
  */
 export function isNLIAvailable() {
+  if (_mode === "disabled") return false;
   if (_mode === "external") return true;
   return !_failed;
 }
@@ -193,6 +194,9 @@ export function isNLIAvailable() {
 export async function classifyNLI(premise, hypothesis) {
   if (_mode === "external") {
     return classifyExternal(premise, hypothesis);
+  }
+  if (_mode === "disabled") {
+    return null;
   }
   return classifyInProcess(premise, hypothesis);
 }
@@ -251,10 +255,20 @@ export async function preloadNLI() {
       const data = await res.json();
       logInfo(`[NLIClassifier] External mode: ${NLI_SERVICE_URL} (model: ${data.model || "unknown"})`);
     } catch (err) {
-      logWarn(`[NLIClassifier] External service health check failed: ${err.message}, falling back to in-process`);
-      _mode = "inprocess";
-      await loadModel();
+      if (INPROCESS_ONNX_ENABLED) {
+        logWarn(`[NLIClassifier] External service health check failed: ${err.message}, falling back to in-process`);
+        _mode = "inprocess";
+        await loadModel();
+      } else {
+        logWarn(`[NLIClassifier] External service health check failed: ${err.message}; in-process ONNX disabled`);
+        _mode = "disabled";
+      }
     }
+    return;
+  }
+
+  if (_mode === "disabled") {
+    logInfo("[NLIClassifier] In-process ONNX disabled by MEMENTO_INPROCESS_ONNX_ENABLED=false");
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "start": "node server.js",
     "test": "npm run test:jest && npm run test:unit:node",
-    "test:jest": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --selectProjects unit",
-    "test:unit:node": "MEMENTO_METRICS_DEFAULT=off node --experimental-test-module-mocks --test 'tests/unit/*.test.js' 'tests/unit/**/*.test.js'",
+    "test:jest": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --selectProjects unit --testMatch \"**/tests/*.test.js\"",
+    "test:unit:node": "node scripts/run-node-unit-tests.js",
     "test:integration": "node --test tests/integration/*.test.js tests/e2e/*.test.js",
     "test:integration:llm": "MEMENTO_METRICS_DEFAULT=off node --test --test-concurrency=1 tests/integration/llm-cli-smoke.test.js tests/integration/llm-timeout.test.js tests/integration/morpheme-llm-real.test.js tests/integration/llm-chain-real.test.js",
     "test:e2e": "node --test --test-concurrency=1 tests/e2e/*.test.js",

--- a/scripts/post-migrate-flexible-embedding-dims.js
+++ b/scripts/post-migrate-flexible-embedding-dims.js
@@ -30,12 +30,18 @@ const TABLES = [
   { table: "morpheme_dict", indexName: "idx_morpheme_dict_embedding",  whereClause: ""                            }
 ];
 
-async function migrateTable(pool, { table, indexName, whereClause }, colType, opsType, targetUdt) {
+async function migrateTable(pool, { table, indexName, whereClause }, colType, opsType) {
   /** 1. 현재 컬럼 타입 조회 */
   const { rows } = await pool.query(
-    `SELECT udt_name
-     FROM information_schema.columns
-     WHERE table_schema = $1 AND table_name = $2 AND column_name = 'embedding'`,
+    `SELECT a.atttypid::regtype::text AS udt_name,
+            format_type(a.atttypid, a.atttypmod) AS formatted_type
+     FROM pg_attribute a
+     JOIN pg_class c ON c.oid = a.attrelid
+     JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = $1
+       AND c.relname = $2
+       AND a.attname = 'embedding'
+       AND NOT a.attisdropped`,
     [SCHEMA, table]
   );
 
@@ -44,10 +50,10 @@ async function migrateTable(pool, { table, indexName, whereClause }, colType, op
     return;
   }
 
-  const currentType = rows[0].udt_name;
+  const currentType = rows[0].formatted_type || rows[0].udt_name;
   console.log(`migration-007: ${table} — 현재 타입: ${currentType}`);
 
-  if (currentType === targetUdt) {
+  if (currentType.toLowerCase() === colType.toLowerCase()) {
     console.log(`migration-007: ${table} — 이미 ${colType}, 스킵`);
     return;
   }
@@ -81,7 +87,6 @@ async function main() {
   const useHalfvec = dims > 2000;
   const colType    = useHalfvec ? `halfvec(${dims})` : `vector(${dims})`;
   const opsType    = useHalfvec ? "halfvec_cosine_ops" : "vector_cosine_ops";
-  const targetUdt  = useHalfvec ? "halfvec" : "vector";
 
   console.log(`EMBEDDING_DIMENSIONS = ${dims}`);
   console.log(`컬럼 타입 → ${colType} (${useHalfvec ? "halfvec — pgvector ≥0.7.0 필요" : "vector"})`);
@@ -90,7 +95,7 @@ async function main() {
 
   try {
     for (const tableSpec of TABLES) {
-      await migrateTable(pool, tableSpec, colType, opsType, targetUdt);
+      await migrateTable(pool, tableSpec, colType, opsType);
     }
 
     console.log("\n마이그레이션 완료 (fragments + morpheme_dict).");

--- a/scripts/run-node-unit-tests.js
+++ b/scripts/run-node-unit-tests.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const unitRoot = path.join(root, "tests", "unit");
+
+function collectTestFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectTestFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith(".test.js")) {
+      files.push(full);
+    }
+  }
+  return files.sort();
+}
+
+const files = collectTestFiles(unitRoot);
+const env = {
+  ...process.env,
+  MEMENTO_METRICS_DEFAULT: "off"
+};
+
+const result = spawnSync(process.execPath, [
+  "--experimental-test-module-mocks",
+  "--test",
+  ...files
+], {
+  cwd: root,
+  env,
+  stdio: "inherit"
+});
+
+process.exit(result.status ?? 1);

--- a/tests/_lifecycle.js
+++ b/tests/_lifecycle.js
@@ -52,11 +52,15 @@ export function defaultIgnore() {
     "GETNAMEINFOREQWRAP",
     "PipeConnectWrap",
     /**
-     * FSReqCallback — winston / logger의 파일 기록 pending. transient.
+     * FSReqCallback / FSReqPromise / FileHandleCloseReq — winston / logger,
+     * ESM loader, and Node's async FileHandle close work can remain visible
+     * briefly as active requests on Windows Node 26.
      * GETADDRINFOREQWRAP — DNS lookup pending.
      * TickObject — micro/macrotask 참조.
      */
     "FSReqCallback",
+    "FSReqPromise",
+    "FileHandleCloseReq",
     "GETADDRINFOREQWRAP",
     "TickObject",
     /**

--- a/tests/unit/assistant-query.test.js
+++ b/tests/unit/assistant-query.test.js
@@ -105,7 +105,7 @@ describe("boostAssistantFragments", () => {
 
     boostAssistantFragments(fragments);
 
-    assert.strictEqual(fragments[0].importance, 0.55);
+    assert.strictEqual(fragments[0].importance, 0.52);
     assert.strictEqual(fragments[1].importance, 0.5);
   });
 
@@ -116,7 +116,7 @@ describe("boostAssistantFragments", () => {
 
     boostAssistantFragments(fragments);
 
-    assert.strictEqual(fragments[0].importance, 0.65);
+    assert.strictEqual(fragments[0].importance, 0.62);
   });
 
   test("importance 최대값 1.0 제한", () => {
@@ -156,6 +156,6 @@ describe("boostAssistantFragments", () => {
 
     boostAssistantFragments(fragments);
 
-    assert.strictEqual(fragments[0].importance, 0.05);
+    assert.strictEqual(fragments[0].importance, 0.02);
   });
 });

--- a/tests/unit/cli-export-import.test.js
+++ b/tests/unit/cli-export-import.test.js
@@ -14,6 +14,7 @@ import assert from "node:assert/strict";
 import fs     from "node:fs";
 import path   from "node:path";
 import os     from "node:os";
+import { fileURLToPath } from "node:url";
 
 /** ---- 헬퍼: 임시 JSONL 파일 ---- */
 function writeTempJsonl(rows) {
@@ -45,7 +46,7 @@ describe("M6: export.js", () => {
 
   it("JSONL 출력 필드 목록이 소스에 포함됨", async () => {
     const src = fs.readFileSync(
-      new URL("../../lib/cli/export.js", import.meta.url).pathname,
+      fileURLToPath(new URL("../../lib/cli/export.js", import.meta.url)),
       "utf8"
     );
     const requiredFields = [
@@ -78,7 +79,7 @@ describe("M6: import.js", () => {
 
   it("JSON parse 에러 처리 — 소스 내 에러 핸들링 확인", async () => {
     const src = fs.readFileSync(
-      new URL("../../lib/cli/import.js", import.meta.url).pathname,
+      fileURLToPath(new URL("../../lib/cli/import.js", import.meta.url)),
       "utf8"
     );
     assert.ok(src.includes("JSON parse error"), "JSON parse 에러 메시지가 소스에 있어야 함");
@@ -87,7 +88,7 @@ describe("M6: import.js", () => {
 
   it("--dry-run 플래그 처리 — INSERT 없이 검증만", async () => {
     const src = fs.readFileSync(
-      new URL("../../lib/cli/import.js", import.meta.url).pathname,
+      fileURLToPath(new URL("../../lib/cli/import.js", import.meta.url)),
       "utf8"
     );
     assert.ok(src.includes("dryRun"), "dry-run 처리 로직이 있어야 함");
@@ -96,7 +97,7 @@ describe("M6: import.js", () => {
 
   it("--idempotent 플래그 — ON CONFLICT DO NOTHING 사용", async () => {
     const src = fs.readFileSync(
-      new URL("../../lib/cli/import.js", import.meta.url).pathname,
+      fileURLToPath(new URL("../../lib/cli/import.js", import.meta.url)),
       "utf8"
     );
     assert.ok(src.includes("ON CONFLICT (id) DO NOTHING"), "idempotent 모드에 ON CONFLICT DO NOTHING이 있어야 함");
@@ -125,7 +126,7 @@ describe("M6: import.js", () => {
 describe("M6: bin/memento.js COMMANDS 등록", () => {
   it("export와 import가 COMMANDS에 등록됨", async () => {
     const src = fs.readFileSync(
-      new URL("../../bin/memento.js", import.meta.url).pathname,
+      fileURLToPath(new URL("../../bin/memento.js", import.meta.url)),
       "utf8"
     );
     assert.ok(src.includes("export:"), "COMMANDS에 export가 등록돼야 함");
@@ -136,7 +137,7 @@ describe("M6: bin/memento.js COMMANDS 등록", () => {
 
   it("export/import가 LOCAL_ONLY_COMMANDS에 포함됨", async () => {
     const src = fs.readFileSync(
-      new URL("../../bin/memento.js", import.meta.url).pathname,
+      fileURLToPath(new URL("../../bin/memento.js", import.meta.url)),
       "utf8"
     );
     /** LOCAL_ONLY_COMMANDS Set 라인 추출 */

--- a/tests/unit/embedding-config-guard.test.js
+++ b/tests/unit/embedding-config-guard.test.js
@@ -10,7 +10,7 @@
 import { test, describe } from "node:test";
 import assert              from "node:assert/strict";
 import { execFileSync }    from "node:child_process";
-import { fileURLToPath }   from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import path                from "node:path";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -24,8 +24,9 @@ const ROOT      = path.resolve(__dirname, "../..");
  * @returns {{ stdout: string, exitCode: number }}
  */
 function runConfigSnippet(env, snippet) {
+  const configUrl = pathToFileURL(path.join(ROOT, "lib", "config.js")).href;
   const script = `
-    import("${ROOT}/lib/config.js")
+    import("${configUrl}")
       .then(cfg => {
         ${snippet}
       })

--- a/tests/unit/install-detector.test.js
+++ b/tests/unit/install-detector.test.js
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import path from "node:path";
 import { detectInstallType } from "../../lib/updater/install-detector.js";
 
 describe("detectInstallType", () => {
@@ -12,25 +13,30 @@ describe("detectInstallType", () => {
   });
 
   it("detects git", async () => {
+    const dirname = path.join(process.cwd(), "fake", "memento-mcp", "lib", "updater");
+    const projectRoot = path.resolve(dirname, "../..");
     assert.equal(await detectInstallType({
-      env: {}, dirname: "/home/user/memento-mcp/lib/updater",
-      fileExists: (p) => p === "/home/user/memento-mcp/.git",
+      env: {}, dirname,
+      fileExists: (p) => p === path.join(projectRoot, ".git"),
       execCommand: () => Promise.resolve("origin\thttps://github.com/JinHo-von-Choi/memento-mcp.git (fetch)")
     }), "git");
   });
 
   it("detects npm-local", async () => {
+    const dirname = path.join(process.cwd(), "project", "node_modules", "memento-mcp", "lib", "updater");
     assert.equal(await detectInstallType({
-      env: {}, dirname: "/project/node_modules/memento-mcp/lib/updater",
+      env: {}, dirname,
       fileExists: () => false, execCommand: () => Promise.reject(new Error("no git"))
     }), "npm-local");
   });
 
   it("detects npm-global", async () => {
+    const prefix = path.join(process.cwd(), "global-prefix");
+    const dirname = path.join(prefix, "node_modules", "memento-mcp", "lib", "updater");
     assert.equal(await detectInstallType({
-      env: {}, dirname: "/usr/local/lib/node_modules/memento-mcp/lib/updater",
+      env: {}, dirname,
       fileExists: () => false,
-      execCommand: (cmd) => cmd === "npm" ? Promise.resolve("/usr/local") : Promise.reject(new Error("no git"))
+      execCommand: (cmd) => cmd === "npm" ? Promise.resolve(prefix) : Promise.reject(new Error("no git"))
     }), "npm-global");
   });
 

--- a/tests/unit/llm-chain-opencode-options.test.js
+++ b/tests/unit/llm-chain-opencode-options.test.js
@@ -33,6 +33,9 @@ mock.module("../../lib/config.js", {
       { provider: "opencode-cli", model: "github-copilot/claude-sonnet-4.5", agent: "general", variant: "low" },
       { provider: "opencode-cli", model: "github-copilot/claude-sonnet-4.5", agent: "general", variant: "high" }
     ],
+    LLM_CHAIN_TIMEOUT_MS    : 0,
+    LLM_PROVIDER_TIMEOUT_MS : 60_000,
+    LLM_PROVIDER_TIMEOUT_CONFIGURED: false,
     LLM_CONCURRENCY_ENABLED : false,
     LLM_CONCURRENCY_WAIT_MS : 30_000,
     getConcurrencyLimit     : () => 1

--- a/tests/unit/onnx-disable.test.js
+++ b/tests/unit/onnx-disable.test.js
@@ -1,0 +1,45 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+
+function runDisabledOnnxSnippet(script) {
+  return execFileSync(process.execPath, ["--input-type=module", "-e", script], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      MEMENTO_INPROCESS_ONNX_ENABLED: "false",
+      MEMENTO_METRICS_DEFAULT: "off",
+      RERANKER_URL: "",
+      NLI_SERVICE_URL: ""
+    }
+  });
+}
+
+describe("MEMENTO_INPROCESS_ONNX_ENABLED=false", () => {
+  it("disables the in-process reranker without loading an ONNX model", () => {
+    const stdout = runDisabledOnnxSnippet(`
+      import assert from "node:assert/strict";
+      const mod = await import("./lib/memory/Reranker.js");
+      assert.equal(mod.isRerankerAvailable(), false);
+      await mod.preloadReranker();
+      const candidates = [{ id: "a", content: "alpha", importance: 0.4 }];
+      const result = await mod.rerank("alpha", candidates, 1);
+      assert.deepEqual(result, candidates);
+      console.log("reranker-disabled-pass");
+    `);
+    assert.match(stdout, /reranker-disabled-pass/);
+  });
+
+  it("disables the in-process NLI classifier without loading an ONNX model", () => {
+    const stdout = runDisabledOnnxSnippet(`
+      import assert from "node:assert/strict";
+      const mod = await import("./lib/memory/signals/NLIClassifier.js");
+      assert.equal(mod.isNLIAvailable(), false);
+      await mod.preloadNLI();
+      assert.equal(await mod.classifyNLI("a premise", "a hypothesis"), null);
+      console.log("nli-disabled-pass");
+    `);
+    assert.match(stdout, /nli-disabled-pass/);
+  });
+});

--- a/tests/unit/search-param-adaptor.test.js
+++ b/tests/unit/search-param-adaptor.test.js
@@ -30,6 +30,7 @@ const { SearchParamAdaptor, _resetForTesting } = await import(
 
 describe("SearchParamAdaptor", () => {
   beforeEach(() => {
+    delete process.env.MEMENTO_SEARCH_PARAM_ADAPTOR_ENABLED;
     mockQuery.mock.resetCalls();
     _resetForTesting();
   });
@@ -103,6 +104,25 @@ describe("SearchParamAdaptor", () => {
     // 예외가 전파되지 않아야 한다
     await adaptor.recordOutcome(42, "keywords", 15, 5);
   });
+
+  test("disabled env: getMinSimilarity returns default without DB query", async () => {
+    process.env.MEMENTO_SEARCH_PARAM_ADAPTOR_ENABLED = "false";
+
+    const adaptor = new SearchParamAdaptor();
+    const result  = await adaptor.getMinSimilarity(null, "text", 10);
+
+    assert.strictEqual(result, 0.35);
+    assert.strictEqual(mockQuery.mock.callCount(), 0);
+  });
+
+  test("disabled env: recordOutcome skips DB write", async () => {
+    process.env.MEMENTO_SEARCH_PARAM_ADAPTOR_ENABLED = "off";
+
+    const adaptor = new SearchParamAdaptor();
+    await adaptor.recordOutcome(null, "text", 10, 3);
+
+    assert.strictEqual(mockQuery.mock.callCount(), 0);
+  });
 });
 
 /**
@@ -118,6 +138,7 @@ describe("SearchParamAdaptor", () => {
  */
 describe("SearchParamAdaptor — array keyId 회귀 (Phase 0 Task 0.4)", () => {
   beforeEach(() => {
+    delete process.env.MEMENTO_SEARCH_PARAM_ADAPTOR_ENABLED;
     mockQuery.mock.resetCalls();
     _resetForTesting();
   });

--- a/tests/unit/tenant-isolation.test.js
+++ b/tests/unit/tenant-isolation.test.js
@@ -1,42 +1,55 @@
 import { describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { SessionLinker } from "../../lib/memory/SessionLinker.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT      = path.resolve(__dirname, "../..");
+const LIB_ROOT  = path.join(ROOT, "lib");
+
+function collectSourceFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith(".js")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function findSourceMatches(pattern) {
+  const matcher = pattern instanceof RegExp
+    ? (line) => pattern.test(line)
+    : (line) => line.includes(pattern);
+  const matches = [];
+  for (const file of collectSourceFiles(LIB_ROOT)) {
+    const rel = path.relative(ROOT, file);
+    const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
+    lines.forEach((line, index) => {
+      if (matcher(line)) {
+        matches.push(`${rel}:${index + 1}:${line}`);
+      }
+    });
+  }
+  return matches.join("\n");
+}
 
 describe("Tenant Isolation — key_id 격리 회귀 방지", () => {
 
   it("lib/ 내에 'key_id IS NULL OR key_id' 패턴이 없어야 함", () => {
-    let matches = "";
-    try {
-      matches = execFileSync("grep", ["-rn", "key_id IS NULL OR key_id", "lib/"], {
-        cwd:      ROOT,
-        encoding: "utf-8"
-      });
-    } catch (e) {
-      // grep exit code 1 = no match = 정상
-      if (e.status === 1) return;
-      throw e;
-    }
+    const matches = findSourceMatches("key_id IS NULL OR key_id");
     assert.equal(matches.trim(), "",
       `금지 패턴 발견:\n${matches}\n\n수정 방법: keyId가 null이면 조건 생략, 값이면 AND key_id = $N만 적용`);
   });
 
   it("lib/ 내에 'key_id' 대상 '::text IS NULL OR' 패턴이 없어야 함 (타입 불일치 방지)", () => {
-    let matches = "";
-    try {
-      matches = execFileSync("grep", ["-rn", "::text IS NULL OR.*key_id", "lib/"], {
-        cwd:      ROOT,
-        encoding: "utf-8"
-      });
-    } catch (e) {
-      if (e.status === 1) return;
-      throw e;
-    }
+    const matches = findSourceMatches(/::text IS NULL OR.*key_id/);
     assert.equal(matches.trim(), "",
       `타입 불일치 패턴 발견:\n${matches}`);
   });


### PR DESCRIPTION
## Summary
- add a managed switch to disable in-process ONNX reranker/NLI loading
- make Node unit tests Windows-safe with a cross-platform runner and path fixes
- add regression coverage for disabled in-process ONNX behavior
- fix flexible embedding migration type detection for vector dimensions

## Verification
- npm test
- targeted onnx-disable and install-detector node tests
- git diff --check