### PR TITLE
fix(reranker): 외부 TEI(text-embeddings-inference) reranker 호환 (texts·배열 응답·빈 /health)

### DIFF
--- a/lib/memory/read/Reranker.js
+++ b/lib/memory/read/Reranker.js
@@ -58,7 +58,7 @@ async function rerankExternal(query, documents) {
     const res = await fetch(`${RERANKER_URL}/rerank`, {
       method:  "POST",
       headers: { "Content-Type": "application/json" },
-      body:    JSON.stringify({ query, documents }),
+      body:    JSON.stringify({ query, texts: documents, documents }),
       signal:  controller.signal
     });
 
@@ -70,6 +70,11 @@ async function rerankExternal(query, documents) {
     }
 
     const data = await res.json();
+    if (Array.isArray(data)) {
+      const scores = new Array(documents.length).fill(0);
+      for (const r of data) { if (typeof r.index === "number") scores[r.index] = r.score; }
+      return scores;
+    }
     return data.scores || null;
   } catch (err) {
     if (err.name === "AbortError") {
@@ -253,8 +258,10 @@ export async function preloadReranker() {
       const res = await fetch(`${RERANKER_URL}/health`, {
         signal: AbortSignal.timeout(3000)
       });
-      const data = await res.json();
-      logInfo(`[Reranker] External mode: ${RERANKER_URL} (model: ${data.model || "unknown"})`);
+      if (!res.ok) throw new Error(`health ${res.status}`);
+      let _rrmodel = "unknown";
+      try { const data = await res.json(); _rrmodel = data.model || "unknown"; } catch (_e) { /* TEI /health returns empty body */ }
+      logInfo(`[Reranker] External mode: ${RERANKER_URL} (model: ${_rrmodel})`);
     } catch (err) {
       logWarn(`[Reranker] External service health check failed: ${err.message}, falling back to in-process`);
       _mode = "inprocess";


### PR DESCRIPTION
## 배경

안녕하세요! AnchorMind를 팀 공유 기억 서버로 도입해 잘 사용하고 있습니다. 훌륭한 프로젝트 만들어 주셔서 감사합니다 🙏

저희는 임베딩·리랭커를 사내 공용 HuggingFace **TEI(text-embeddings-inference)** 스택(`bge-m3` / `bge-reranker`)으로 재사용하고 있는데, 현재 `lib/memory/read/Reranker.js`의 외부 reranker 연동이 TEI의 `/rerank`·`/health` 규격과 맞지 않아 **external 모드가 항상 실패하고 in-process로 폴백**됩니다.

## 원인 (TEI 규격 차이)

1. **요청 필드** — TEI `/rerank`는 문서 배열을 `texts`로 받습니다. 현재는 `documents`만 전송해 요청이 거부됩니다.
2. **응답 형식** — TEI는 `{ "scores": [...] }`가 아니라 `[{ "index": n, "score": s }, ...]` 배열을 반환합니다. 현재 `data.scores`만 읽어 항상 `null`이 됩니다.
3. **health 바디** — TEI `/health`는 200 + 빈 바디를 반환해 `res.json()`이 throw → 헬스체크가 실패하여 external이 비활성화됩니다.

## 변경 내용

- 요청 바디에 `texts`를 추가합니다(기존 `documents`도 함께 전송하여 하위호환 유지).
- 응답이 배열이면 `index`로 점수를 매핑하고, 배열이 아니면 기존 `data.scores`로 fallback합니다.
- `/health`는 `res.ok`만 확인하고 바디 파싱 실패를 graceful하게 처리합니다(모델명은 `unknown` 허용).

기존 `{documents}` 요청 / `{scores}` 응답 규격 서버와도 **하위호환**됩니다.

## 요청

현재는 사내 포크로 이 패치를 안고 운영 중입니다. 팀 표준 리랭커가 TEI다 보니 같은 스택을 쓰는 다른 사용자분들도 겪을 수 있는 케이스라 생각되어, 괜찮으시다면 업스트림 반영을 조심스럽게 요청드립니다. 네이밍이나 구현 방식은 메인테이너님 의견에 맞춰 얼마든지 조정하겠습니다. 검토 감사합니다! 🙇
