### PR TITLE
context 앵커 workspace 및 peer agent 조회 스코프 일관화

### DIFF
--- a/lib/memory/link/LinkStore.js
+++ b/lib/memory/link/LinkStore.js
@@ -185,10 +185,19 @@ export class LinkStore {
    * @param {string[]}    fromIds
    * @param {string|null} relationType
    * @param {string}      agentId
-   * @param {number|null} keyId  - API 키 격리 필터 (null=master, 전체 조회)
+   * @param {string|string[]|null} keyId  - API 키 격리 필터 (null=master, 전체 조회)
+   * @param {Object}      opts
+   * @param {string|null} opts.workspace
+   * @param {boolean}     opts.includePeerAgents
    * @returns {Promise<object[]>}
    */
-  async getLinkedFragments(fromIds, relationType = null, agentId = "default", keyId = null) {
+  async getLinkedFragments(
+    fromIds,
+    relationType = null,
+    agentId = "default",
+    keyId = null,
+    opts = {}
+  ) {
     if (fromIds.length === 0) return [];
 
     const ALLOWED_RELATION_TYPES = new Set([
@@ -197,9 +206,21 @@ export class LinkStore {
     const safeRelationType = relationType && ALLOWED_RELATION_TYPES.has(relationType)
       ? relationType
       : null;
+    const {
+      workspace = null,
+      includePeerAgents = false
+    } = opts || {};
+    const effectiveAgentId = agentId || "default";
 
-    const { sql, params } = this._buildLinkedFragmentsSql({ fromIds, safeRelationType, keyId });
-    const result          = await queryWithAgentVector(agentId, sql, params);
+    const { sql, params } = this._buildLinkedFragmentsSql({
+      fromIds,
+      safeRelationType,
+      keyId,
+      agentId: effectiveAgentId,
+      workspace,
+      includePeerAgents
+    });
+    const result = await queryWithAgentVector(effectiveAgentId, sql, params);
 
     return result.rows;
   }
@@ -210,10 +231,20 @@ export class LinkStore {
    * @param {object}      opts
    * @param {string[]|null} opts.fromIds          - $1 에 바인딩될 ID 배열
    * @param {string|null} opts.safeRelationType   - 검증된 relation_type 값, null이면 기본 4종 IN 필터
-   * @param {number|null} opts.keyId              - API 키 격리 필터
+   * @param {string|string[]|null} opts.keyId     - API 키 격리 필터
+   * @param {string}      opts.agentId
+   * @param {string|null} opts.workspace
+   * @param {boolean}     opts.includePeerAgents
    * @returns {{ sql: string, params: any[] }}
    */
-  _buildLinkedFragmentsSql({ fromIds, safeRelationType, keyId }) {
+  _buildLinkedFragmentsSql({
+    fromIds,
+    safeRelationType,
+    keyId,
+    agentId = "default",
+    workspace = null,
+    includePeerAgents = false
+  }) {
     const params       = safeRelationType ? [fromIds, safeRelationType] : [fromIds];
     const relationWhere = safeRelationType
       ? `AND l.relation_type = $2`
@@ -225,15 +256,27 @@ export class LinkStore {
       keyFilter = `AND f.key_id = ANY($${params.length})`;
     }
 
+    let agentFilter = "";
+    if (!includePeerAgents) {
+      params.push(agentId);
+      agentFilter = `AND (f.agent_id = $${params.length} OR f.agent_id = 'default')`;
+    }
+
+    let workspaceFilter = "";
+    if (workspace !== null) {
+      params.push(workspace);
+      workspaceFilter = `AND (f.workspace = $${params.length} OR f.workspace IS NULL)`;
+    }
+
     const sql = `SELECT DISTINCT ON (id)
                          id, content, topic, keywords, type,
                          importance, linked_to, access_count,
-                         created_at, verified_at, relation_type,
+                         created_at, verified_at, agent_id, workspace, relation_type,
                          link_weight, relation_order
          FROM (
            SELECT f.id, f.content, f.topic, f.keywords, f.type,
                   f.importance, f.linked_to, f.access_count,
-                  f.created_at, f.verified_at, l.relation_type,
+                  f.created_at, f.verified_at, f.agent_id, f.workspace, l.relation_type,
                   COALESCE(l.weight, 1) AS link_weight,
                   CASE l.relation_type
                     WHEN 'resolved_by' THEN 1
@@ -245,10 +288,12 @@ export class LinkStore {
            WHERE l.from_id = ANY($1)
              ${relationWhere}
              ${keyFilter}
+             ${agentFilter}
+             ${workspaceFilter}
            UNION ALL
            SELECT f.id, f.content, f.topic, f.keywords, f.type,
                   f.importance, f.linked_to, f.access_count,
-                  f.created_at, f.verified_at, l.relation_type,
+                  f.created_at, f.verified_at, f.agent_id, f.workspace, l.relation_type,
                   COALESCE(l.weight, 1) AS link_weight,
                   CASE l.relation_type
                     WHEN 'resolved_by' THEN 1
@@ -260,6 +305,8 @@ export class LinkStore {
            WHERE l.to_id = ANY($1)
              ${relationWhere}
              ${keyFilter}
+             ${agentFilter}
+             ${workspaceFilter}
          ) sub
          ORDER BY id, link_weight DESC, relation_order, importance DESC
          LIMIT ${MEMORY_CONFIG.linkedFragmentLimit}`;

--- a/lib/memory/processors/MemoryRecaller.js
+++ b/lib/memory/processors/MemoryRecaller.js
@@ -18,6 +18,7 @@ import { CaseRecall }            from "../read/CaseRecall.js";
 import { deriveImplicitKeywords, lexicalMatchScore } from "../read/FragmentSearch.js";
 import { extractRequestCtx }                        from "../keyId.js";
 import { enrichWithKeyNames }                        from "../read/KeyNameEnricher.js";
+import { SearchScope }                               from "../read/SearchScope.js";
 
 /**
  * 파편의 stale 여부를 계산한다. verified_at이 없으면 created_at으로 폴백하고,
@@ -127,10 +128,22 @@ export class MemoryRecaller {
         fromIds,
         params.linkRelationType || null,
         agentId,
-        groupKeyIds
+        groupKeyIds,
+        {
+          workspace,
+          includePeerAgents: params.includePeerAgents === true
+        }
       );
+      const linkedScope = SearchScope.fromQuery({
+        agentId,
+        workspace,
+        includePeerAgents: params.includePeerAgents === true
+      });
+      const scopedLinkedFrags = linkedScope.isNoop()
+        ? linkedFrags
+        : linkedFrags.filter(fragment => linkedScope.applyTo(fragment));
 
-      for (const lf of linkedFrags) {
+      for (const lf of scopedLinkedFrags) {
         if (!existingIds.has(lf.id)) {
           lf._source = "linked";
           result.fragments.push(lf);

--- a/lib/memory/processors/MemoryRecaller.js
+++ b/lib/memory/processors/MemoryRecaller.js
@@ -379,7 +379,10 @@ export class MemoryRecaller {
     const { agentId, keyId, groupKeyIds } = extractRequestCtx(params, { groupKeyIdsFallback: 'empty' });
 
     /** getHistory 내부 getById에 keyId 전달 — SQL 레벨 필터로 권한 없으면 current=null */
-    const result = await this.store.getHistory(params.id, agentId, keyId, groupKeyIds);
+    const result = await this.store.getHistory(
+      params.id, agentId, keyId, groupKeyIds,
+      { includePeerAgents: params.includePeerAgents === true }
+    );
     if (!result.current) return { error: "Fragment not found or no permission" };
 
     return result;

--- a/lib/memory/read/ContextBuilder.js
+++ b/lib/memory/read/ContextBuilder.js
@@ -123,7 +123,7 @@ export class ContextBuilder {
 
     const { wmFragments, wmChars } = await this.#loadWorkingMemory(params);
 
-    const anchorFragments = await this.#loadAnchorMemory(groupKeyIds);
+    const anchorFragments = await this.#loadAnchorMemory(groupKeyIds, workspace);
 
     await this.#loadLearningFragments(typeFragMap, types, agentId, keyId);
 
@@ -346,9 +346,11 @@ export class ContextBuilder {
    * 개수 상한은 contextInjection.maxAnchorFragments (env MEMENTO_CONTEXT_ANCHOR_LIMIT).
    * 앵커는 토큰 예산 절삭 대상이 아니므로 이 상한이 유일한 주입량 제한이다.
    *
+   * @param {string[]|null} groupKeyIds
+   * @param {string|null} workspace - 지정 시 동일 workspace와 전역(NULL) 앵커만 허용
    * @returns {object[]}
    */
-  async #loadAnchorMemory(groupKeyIds) {
+  async #loadAnchorMemory(groupKeyIds, workspace) {
     let anchorFragments = [];
     try {
       const pool = this.#getPool();
@@ -359,6 +361,11 @@ export class ContextBuilder {
           anchorParams.push(groupKeyIds);
           anchorKeyFilter = `AND key_id = ANY($${anchorParams.length})`;
         }
+        let anchorWorkspaceFilter = "";
+        if (workspace != null) {
+          anchorParams.push(workspace);
+          anchorWorkspaceFilter = `AND (workspace = $${anchorParams.length} OR workspace IS NULL)`;
+        }
         const maxAnchors = MEMORY_CONFIG.contextInjection?.maxAnchorFragments || 10;
         anchorParams.push(maxAnchors);
         const anchorResult = await pool.query(
@@ -367,6 +374,7 @@ export class ContextBuilder {
             WHERE is_anchor = TRUE
               AND valid_to IS NULL
               ${anchorKeyFilter}
+              ${anchorWorkspaceFilter}
             ORDER BY importance DESC
             LIMIT $${anchorParams.length}`,
           anchorParams

--- a/lib/memory/read/FragmentReader.js
+++ b/lib/memory/read/FragmentReader.js
@@ -153,10 +153,11 @@ export class FragmentReader {
    * @param {string}      agentId
    * @param {string|null} keyId       - null: 마스터(전체), string: 해당 API 키 소유만
    * @param {string[]}    groupKeyIds - 그룹 키 목록
+   * @param {Object}      opts        - `{ includePeerAgents?: boolean }`
    * @returns {Promise<Object>} { current, versions, superseded_by_chain }
    */
-  async getHistory(fragmentId, agentId = "default", keyId = null, groupKeyIds = []) {
-    const current = await this.getById(fragmentId, agentId, keyId, groupKeyIds);
+  async getHistory(fragmentId, agentId = "default", keyId = null, groupKeyIds = [], opts = {}) {
+    const current = await this.getById(fragmentId, agentId, keyId, groupKeyIds, opts);
 
     const versions = await queryWithAgentVector(agentId,
       `SELECT fragment_id, content, topic, keywords, type, importance,

--- a/lib/memory/read/FragmentReader.js
+++ b/lib/memory/read/FragmentReader.js
@@ -23,7 +23,7 @@ const SCHEMA = "agent_memory";
 const SEARCH_COLS_BASE = [
   "f.id", "f.content", "f.topic", "f.keywords", "f.type", "f.importance", "f.utility_score",
   "f.linked_to", "f.access_count", "f.created_at", "f.verified_at", "f.is_anchor", "f.valid_to",
-  "f.key_id", "f.context_summary", "f.session_id", "f.workspace",
+  "f.key_id", "f.agent_id", "f.context_summary", "f.session_id", "f.workspace",
   "f.case_id", "f.goal", "f.outcome", "f.phase", "f.resolution_status", "f.assertion_status",
   "f.affect"
 ].join(",\n                    ");

--- a/lib/memory/read/FragmentSearch.js
+++ b/lib/memory/read/FragmentSearch.js
@@ -296,7 +296,8 @@ export class FragmentSearch {
       caseId            : query.caseId || undefined,
       resolutionStatus  : query.resolutionStatus || undefined,
       phase             : query.phase || undefined,
-      affect            : query.affect || undefined
+      affect            : query.affect || undefined,
+      includePeerAgents : query.includePeerAgents === true
     };
 
     // SearchParamAdaptor: 학습된 minSimilarity 주입 (비동기 -> Promise로 저장, _searchL3에서 await)
@@ -315,7 +316,7 @@ export class FragmentSearch {
    * @returns {Promise<{ combined: Object[], searchPath: string[], l1IsFallback: boolean, layerLatency: Object }>}
    */
   async _executeSearch(sq, _metricsP) {
-    const { agentId, keyId, workspace, timeRange } = sq;
+    const { agentId, keyId, timeRange } = sq;
     const searchPath  = [];
     const layerLatency = { l1Ms: null, l2Ms: null, l3Ms: null, temporalMs: null, graphUsed: false };
 
@@ -410,8 +411,14 @@ export class FragmentSearch {
     /** L2.5 Graph: L2 상위 파편의 1-hop 이웃 수집 */
     const graphSeedCount = MEMORY_CONFIG.graph?.seedCount || 10;
     const l2TopIds       = l2Results.slice(0, graphSeedCount).map(f => f.id);
-    const rawGraphResults = await fetchGraphNeighbors(l2TopIds, 10, agentId, keyId).catch(() => []);
-    /** Graph 결과를 scope로 정합 필터링. fetchGraphNeighbors 시그니처 변경 없이 호출 사이트에서 적용. */
+    const rawGraphResults = await fetchGraphNeighbors(
+      l2TopIds,
+      10,
+      agentId,
+      keyId,
+      { workspace: sq.workspace, includePeerAgents: sq.includePeerAgents === true }
+    ).catch(() => []);
+    /** Graph 결과를 scope로 다시 정합 필터링하여 SQL 필터를 방어적으로 보강한다. */
     const graphResults = scope.isNoop() ? rawGraphResults : rawGraphResults.filter(f => scope.applyTo(f));
     if (graphResults.length > 0) {
       searchPath.push(`L2.5Graph:${graphResults.length}`);

--- a/lib/memory/read/GraphNeighborSearch.js
+++ b/lib/memory/read/GraphNeighborSearch.js
@@ -18,17 +18,31 @@ const SCHEMA = "agent_memory";
  *
  * @param {string[]}    seedIds  - L2 상위 파편 ID 배열 (최대 5개)
  * @param {number}      maxTotal - 최대 반환 수 (기본 10)
- * @param {string}      agentId  - 에이전트 ID (미사용, 향후 RLS 확장 대비)
+ * @param {string}      agentId  - 에이전트 ID
  * @param {string|null} keyId    - API 키 격리 필터
+ * @param {Object}      opts
+ * @param {string|null} opts.workspace
+ * @param {boolean}     opts.includePeerAgents
  * @returns {Promise<Object[]>} 이웃 파편 배열 (id, content, topic, type, importance 등)
  */
-export async function fetchGraphNeighbors(seedIds, maxTotal = 10, _agentId = "default", keyId = null) {
+export async function fetchGraphNeighbors(
+  seedIds,
+  maxTotal = 10,
+  agentId = "default",
+  keyId = null,
+  opts = {}
+) {
   if (!seedIds || seedIds.length === 0) return [];
 
   const validIds = seedIds.filter(id => typeof id === "string" && id.length > 0);
   if (validIds.length === 0) return [];
 
   const pool = getPrimaryPool();
+  const {
+    workspace = null,
+    includePeerAgents = false
+  } = opts || {};
+  const effectiveAgentId = agentId || "default";
 
   /** keyId 정규화: 단일 값 또는 배열 모두 문자열 배열로 통일. null이면 마스터(필터 없음). */
   const effectiveKeyId = Array.isArray(keyId)
@@ -36,12 +50,22 @@ export async function fetchGraphNeighbors(seedIds, maxTotal = 10, _agentId = "de
     : (keyId != null ? [String(keyId)] : null);
   if (effectiveKeyId !== null && effectiveKeyId.length === 0) return [];
 
-  let keyFilter = "";
-  const params  = [validIds, validIds, maxTotal];
+  let keyFilter       = "";
+  let agentFilter     = "";
+  let workspaceFilter = "";
+  const params        = [validIds, validIds, maxTotal];
 
   if (effectiveKeyId !== null) {
     keyFilter = `AND f.key_id = ANY($4::text[])`;
     params.push(effectiveKeyId);
+  }
+  if (!includePeerAgents) {
+    params.push(effectiveAgentId);
+    agentFilter = `AND (f.agent_id = $${params.length} OR f.agent_id = 'default')`;
+  }
+  if (workspace !== null) {
+    params.push(workspace);
+    workspaceFilter = `AND (f.workspace = $${params.length} OR f.workspace IS NULL)`;
   }
 
   /**
@@ -52,11 +76,12 @@ export async function fetchGraphNeighbors(seedIds, maxTotal = 10, _agentId = "de
   const { rows } = await pool.query(
     `SELECT DISTINCT ON (id)
             id, content, topic, keywords, type, importance,
-            utility_score, access_count, created_at, is_anchor, valid_to,
+            utility_score, access_count, created_at, is_anchor, valid_to, agent_id, workspace,
             _link_weight, _relation_type
        FROM (
          SELECT f.id, f.content, f.topic, f.keywords, f.type, f.importance,
                 f.utility_score, f.access_count, f.created_at, f.is_anchor, f.valid_to,
+                f.agent_id, f.workspace,
                 fl.weight AS _link_weight,
                 fl.relation_type AS _relation_type
            FROM ${SCHEMA}.fragment_links fl
@@ -66,9 +91,12 @@ export async function fetchGraphNeighbors(seedIds, maxTotal = 10, _agentId = "de
             AND fl.deleted_at IS NULL
             AND f.valid_to IS NULL
             ${keyFilter}
+            ${agentFilter}
+            ${workspaceFilter}
          UNION ALL
          SELECT f.id, f.content, f.topic, f.keywords, f.type, f.importance,
                 f.utility_score, f.access_count, f.created_at, f.is_anchor, f.valid_to,
+                f.agent_id, f.workspace,
                 fl.weight AS _link_weight,
                 fl.relation_type AS _relation_type
            FROM ${SCHEMA}.fragment_links fl
@@ -78,6 +106,8 @@ export async function fetchGraphNeighbors(seedIds, maxTotal = 10, _agentId = "de
             AND fl.deleted_at IS NULL
             AND f.valid_to IS NULL
             ${keyFilter}
+            ${agentFilter}
+            ${workspaceFilter}
        ) sub
       ORDER BY id, _link_weight DESC
       LIMIT $3`,

--- a/lib/memory/read/SearchScope.js
+++ b/lib/memory/read/SearchScope.js
@@ -4,7 +4,7 @@
  * 작성자: 최진호
  * 작성일: 2026-05-13
  *
- * workspace, caseId, resolutionStatus, phase, affect 5개 필드를
+ * agent, workspace, caseId, resolutionStatus, phase, affect 필드를
  * 각 검색 레이어(HotCache, L3, Graph 호출 사이트)에서 fragment 단위로
  * 일관되게 필터링하기 위한 단일 계약 객체.
  *
@@ -24,17 +24,30 @@ export class SearchScope {
    * @param {string|undefined}      opts.phase
    * @param {string|string[]|undefined} opts.affect
    * @param {string|null}           opts.keyId
+   * @param {string|null}           opts.agentId
+   * @param {boolean}               opts.includePeerAgents
    */
-  constructor({ workspace = null, caseId, resolutionStatus, phase, affect, keyId = null } = {}) {
-    this.workspace        = workspace;
-    this.caseId           = caseId;
-    this.resolutionStatus = resolutionStatus;
-    this.phase            = phase;
+  constructor({
+    workspace = null,
+    caseId,
+    resolutionStatus,
+    phase,
+    affect,
+    keyId = null,
+    agentId = null,
+    includePeerAgents = false
+  } = {}) {
+    this.workspace         = workspace;
+    this.caseId            = caseId;
+    this.resolutionStatus  = resolutionStatus;
+    this.phase             = phase;
     /** affect는 배열로 정규화하여 보관. 미지정이면 null. */
-    this.affectSet        = affect
+    this.affectSet         = affect
       ? new Set(Array.isArray(affect) ? affect : [affect])
       : null;
-    this.keyId            = keyId;
+    this.keyId             = keyId;
+    this.agentId           = agentId;
+    this.includePeerAgents = includePeerAgents;
   }
 
   /**
@@ -45,6 +58,14 @@ export class SearchScope {
    */
   applyTo(fragment) {
     if (!fragment) return false;
+
+    /** agent: SQL의 (agent_id = $agentId OR agent_id = 'default')와 동일한 계약.
+     *  agentId 미지정 또는 includePeerAgents=true면 agent 조건을 적용하지 않는다. */
+    if (this.agentId !== null && !this.includePeerAgents) {
+      if (fragment.agent_id !== this.agentId && fragment.agent_id !== "default") {
+        return false;
+      }
+    }
 
     /** workspace: null scope는 모든 workspace 허용.
      *  non-null scope는 fragment.workspace가 scope와 일치하거나 null(전역)인 경우만 허용. */
@@ -81,11 +102,12 @@ export class SearchScope {
    */
   isNoop() {
     return (
-      this.workspace        === null  &&
-      this.caseId           === undefined &&
-      this.resolutionStatus === undefined &&
-      this.phase            === undefined &&
-      this.affectSet        === null
+      this.agentId           === null &&
+      this.workspace         === null &&
+      this.caseId            === undefined &&
+      this.resolutionStatus  === undefined &&
+      this.phase             === undefined &&
+      this.affectSet         === null
     );
   }
 
@@ -102,7 +124,9 @@ export class SearchScope {
       resolutionStatus: sq.resolutionStatus,
       phase           : sq.phase,
       affect          : sq.affect,
-      keyId           : sq.keyId            ?? null
+      keyId           : sq.keyId            ?? null,
+      agentId         : sq.agentId          ?? null,
+      includePeerAgents: sq.includePeerAgents === true
     });
   }
 }

--- a/lib/memory/write/FragmentStore.js
+++ b/lib/memory/write/FragmentStore.js
@@ -64,7 +64,7 @@ export class FragmentStore {
 
   createLink(fromId, toId, relationType, agentId, weight)              { return this.links.createLink(fromId, toId, relationType, agentId, weight); }
   createLinks(pairs, agentId)                                          { return this.links.createLinks(pairs, agentId); }
-  getLinkedFragments(fromIds, relationType, agentId, keyId)           { return this.links.getLinkedFragments(fromIds, relationType, agentId, keyId); }
+  getLinkedFragments(fromIds, relationType, agentId, keyId, opts = {}) { return this.links.getLinkedFragments(fromIds, relationType, agentId, keyId, opts); }
   getLinkedIds(fragmentId, agentId, keyId)                            { return this.links.getLinkedIds(fragmentId, agentId, keyId); }
   isReachable(startId, targetId, agentId, keyId)                      { return this.links.isReachable(startId, targetId, agentId, keyId); }
   getRCAChain(startId, agentId, keyId, groupKeyIds)                   { return this.links.getRCAChain(startId, agentId, keyId, groupKeyIds); }

--- a/lib/memory/write/FragmentStore.js
+++ b/lib/memory/write/FragmentStore.js
@@ -23,13 +23,13 @@ export class FragmentStore {
 
   // ── Read delegations ────────────────────────────────────────────────────────
 
-  getById(id, agentId, keyId, groupKeyIds)                            { return this.reader.getById(id, agentId, keyId, groupKeyIds); }
-  getByIds(ids, agentId, keyId, groupKeyIds)                          { return this.reader.getByIds(ids, agentId, keyId, groupKeyIds); }
-  getHistory(fragmentId, agentId, keyId, groupKeyIds)                 { return this.reader.getHistory(fragmentId, agentId, keyId, groupKeyIds); }
+  getById(id, agentId, keyId, groupKeyIds, opts)                      { return this.reader.getById(id, agentId, keyId, groupKeyIds, opts); }
+  getByIds(ids, agentId, keyId, groupKeyIds, opts)                    { return this.reader.getByIds(ids, agentId, keyId, groupKeyIds, opts); }
+  getHistory(fragmentId, agentId, keyId, groupKeyIds, opts)           { return this.reader.getHistory(fragmentId, agentId, keyId, groupKeyIds, opts); }
   searchByKeywords(keywords, options)                                  { return this.reader.searchByKeywords(keywords, options); }
   searchByTopic(topic, options)                                        { return this.reader.searchByTopic(topic, options); }
-  searchBySemantic(queryEmbedding, limit, minSimilarity, agentId, keyId, includeSuperseded, timeRange, workspace, affect, morphemeOnly = false) {
-    return this.reader.searchBySemantic(queryEmbedding, limit, minSimilarity, agentId, keyId, includeSuperseded, timeRange, workspace, affect, morphemeOnly);
+  searchBySemantic(queryEmbedding, limit, minSimilarity, agentId, keyId, includeSuperseded, timeRange, workspace, affect, morphemeOnly = false, includePeerAgents = false) {
+    return this.reader.searchBySemantic(queryEmbedding, limit, minSimilarity, agentId, keyId, includeSuperseded, timeRange, workspace, affect, morphemeOnly, includePeerAgents);
   }
   searchByTimeRange(from, to, options)                                  { return this.reader.searchByTimeRange(from, to, options); }
   searchAsOf(asOf, agentId, opts, keyId)                               { return this.reader.searchAsOf(asOf, agentId, opts, keyId); }

--- a/lib/tools/memory-schemas.js
+++ b/lib/tools/memory-schemas.js
@@ -1012,6 +1012,12 @@ export const fragmentHistoryDefinition = {
         type       : "string",
         description: "조회할 파편 ID (필수). recall 응답의 id 필드 값을 사용한다.",
         examples   : ["frag-abc123", "frag-def456"]
+      },
+      agentId: COMMON_PARAMS.agentId,
+      includePeerAgents: {
+        type       : "boolean",
+        description: "true 시 같은 API 키 스코프 내 다른 agentId의 파편 이력도 조회한다. 테넌트(키) 경계는 완화되지 않는다. 기본 false.",
+        examples   : [false, true]
       }
     },
     required: ["id"]

--- a/tests/unit/context-anchor-limit.test.js
+++ b/tests/unit/context-anchor-limit.test.js
@@ -95,6 +95,50 @@ describe("ContextBuilder 앵커 주입", () => {
     );
   });
 
+  it("workspace 지정 시 동일 workspace와 전역(NULL) 앵커만 조회한다", async () => {
+    let captured = null;
+    const builder = makeBuilder(async (sql, params) => {
+      captured = { sql, params };
+      return { rows: [] };
+    });
+
+    await builder.build({ workspace: "mcps" });
+
+    assert.match(captured.sql, /AND \(workspace = \$\d+ OR workspace IS NULL\)/);
+    assert.deepEqual(captured.params, [
+      "mcps",
+      MEMORY_CONFIG.contextInjection.maxAnchorFragments
+    ]);
+  });
+
+  it("키의 default workspace도 앵커 조회에 적용한다", async () => {
+    let captured = null;
+    const builder = makeBuilder(async (sql, params) => {
+      captured = { sql, params };
+      return { rows: [] };
+    });
+
+    await builder.build({ _defaultWorkspace: "team-default" });
+
+    assert.match(captured.sql, /AND \(workspace = \$\d+ OR workspace IS NULL\)/);
+    assert.deepEqual(captured.params, [
+      "team-default",
+      MEMORY_CONFIG.contextInjection.maxAnchorFragments
+    ]);
+  });
+
+  it("workspace가 없으면 기존처럼 앵커 workspace 필터를 추가하지 않는다", async () => {
+    let captured = null;
+    const builder = makeBuilder(async (sql, params) => {
+      captured = { sql, params };
+      return { rows: [] };
+    });
+
+    await builder.build({});
+
+    assert.doesNotMatch(captured.sql, /workspace = \$\d+/);
+  });
+
   it("structured=true에서 앵커 파편(원래 type 유지)이 rankedInjection 상단에 고정된다", async () => {
     const anchorRows = [
       { id: "anc-1", type: "preference", topic: "t", content: "anchor pref", importance: 1.0 },

--- a/tests/unit/fragment-history.test.js
+++ b/tests/unit/fragment-history.test.js
@@ -13,4 +13,25 @@ describe("fragment history", () => {
     const mm = new MemoryManager();
     assert.strictEqual(typeof mm.fragmentHistory, "function");
   });
+
+  test("includePeerAgents를 저장소 조회 옵션으로 전달한다", async () => {
+    let captured = null;
+    const store = {
+      getHistory: async (...args) => {
+        captured = args;
+        return { current: { id: "frag-peer" }, versions: [], superseded_by_chain: [] };
+      }
+    };
+    const { MemoryRecaller } = await import("../../lib/memory/processors/MemoryRecaller.js");
+    const recaller = new MemoryRecaller({ store });
+
+    const result = await recaller.fragmentHistory({
+      id               : "frag-peer",
+      agentId          : "default",
+      includePeerAgents: true
+    });
+
+    assert.equal(result.current.id, "frag-peer");
+    assert.deepEqual(captured[4], { includePeerAgents: true });
+  });
 });

--- a/tests/unit/recall-peer-agent-isolation-integration.test.js
+++ b/tests/unit/recall-peer-agent-isolation-integration.test.js
@@ -1,0 +1,459 @@
+/**
+ * recall agent/workspace 격리 우회 통합 회귀 테스트
+ *
+ * 작성자: 최진호
+ * 작성일: 2026-07-25
+ *
+ * Hot Cache, L2.5 Graph, 기본 includeLinks 병합이 SQL 및 최종 결과에서
+ * 동일한 agent/workspace 스코프를 적용하는지 검증한다.
+ */
+
+import { beforeEach, describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+function createRedisMock() {
+  const sets    = new Map();
+  const sorted  = new Map();
+  const strings = new Map();
+
+  const redis = {
+    status: "ready",
+
+    async sadd(key, ...members) {
+      if (!sets.has(key)) sets.set(key, new Set());
+      for (const member of members) sets.get(key).add(member);
+      return members.length;
+    },
+
+    async smembers(key) {
+      return [...(sets.get(key) ?? [])];
+    },
+
+    async sinter(...keys) {
+      if (keys.length === 0) return [];
+      const intersection = new Set(sets.get(keys[0]) ?? []);
+      for (const key of keys.slice(1)) {
+        const values = sets.get(key) ?? new Set();
+        for (const value of [...intersection]) {
+          if (!values.has(value)) intersection.delete(value);
+        }
+      }
+      return [...intersection];
+    },
+
+    async sunion(...keys) {
+      const union = new Set();
+      for (const key of keys) {
+        for (const value of (sets.get(key) ?? [])) union.add(value);
+      }
+      return [...union];
+    },
+
+    async zadd(key, score, member) {
+      if (!sorted.has(key)) sorted.set(key, new Map());
+      sorted.get(key).set(member, score);
+      return 1;
+    },
+
+    async zrevrange(key, start, stop) {
+      const entries = [...(sorted.get(key) ?? new Map()).entries()]
+        .sort((a, b) => b[1] - a[1]);
+      const end = stop < 0 ? entries.length : stop + 1;
+      return entries.slice(start, end).map(([member]) => member);
+    },
+
+    async setex(key, _ttl, value) {
+      strings.set(key, value);
+      return "OK";
+    },
+
+    async get(key) {
+      return strings.get(key) ?? null;
+    },
+
+    pipeline() {
+      const operations = [];
+      const pipeline = {
+        sadd(key, ...members) {
+          operations.push(() => redis.sadd(key, ...members));
+          return pipeline;
+        },
+        zadd(key, score, member) {
+          operations.push(() => redis.zadd(key, score, member));
+          return pipeline;
+        },
+        expire() {
+          operations.push(() => Promise.resolve(1));
+          return pipeline;
+        },
+        async exec() {
+          for (const operation of operations) await operation();
+          return [];
+        }
+      };
+      return pipeline;
+    }
+  };
+
+  return redis;
+}
+
+const redisRef = { current: createRedisMock() };
+const redisProxy = new Proxy(redisRef, {
+  get(ref, prop) {
+    const value = ref.current[prop];
+    return typeof value === "function" ? value.bind(ref.current) : value;
+  }
+});
+
+let vectorQueries = [];
+let graphQueries  = [];
+let graphRows     = [];
+let linkedRows    = [];
+
+mock.module("../../lib/redis.js", {
+  namedExports: { redisClient: redisProxy }
+});
+
+mock.module("../../lib/logger.js", {
+  namedExports: {
+    logDebug: mock.fn(),
+    logInfo : mock.fn(),
+    logWarn : mock.fn(),
+    logError: mock.fn()
+  }
+});
+
+mock.module("../../lib/tools/db.js", {
+  namedExports: {
+    queryWithAgentVector: async (agentId, sql, params) => {
+      vectorQueries.push({ agentId, sql, params });
+      return { rows: linkedRows.map(row => ({ ...row })) };
+    },
+    getPrimaryPool: () => ({
+      query: async (sql, params) => {
+        graphQueries.push({ sql, params });
+        return { rows: graphRows.map(row => ({ ...row })) };
+      }
+    }),
+    getBatchPool   : () => null,
+    shutdownPool   : async () => {},
+    getPoolStats   : () => ({}),
+    withTransaction: async (_pool, fn) => fn({ query: async () => ({ rows: [] }) })
+  }
+});
+
+mock.module("../../lib/tools/embedding.js", {
+  namedExports: {
+    EMBEDDING_ENABLED      : false,
+    computeContentHash     : () => "hash",
+    generateBatchEmbeddings: async () => [],
+    generateEmbedding      : async () => [],
+    prepareTextForEmbedding: text => String(text ?? ""),
+    vectorToSql            : vector => `[${vector.join(",")}]`
+  }
+});
+
+mock.module("../../lib/memory/write/FragmentFactory.js", {
+  namedExports: {
+    FragmentFactory: class {
+      extractKeywords() { return []; }
+    },
+    countTokens: text => Math.max(1, Math.ceil(String(text ?? "").length / 4))
+  }
+});
+
+mock.module("../../lib/memory/signals/SearchMetrics.js", {
+  namedExports: {
+    getSearchMetrics: async () => ({ record: async () => {} })
+  }
+});
+
+mock.module("../../lib/memory/signals/SearchParamAdaptor.js", {
+  namedExports: {
+    getSearchParamAdaptor: () => ({ getMinSimilarity: async () => null })
+  }
+});
+
+mock.module("../../lib/memory/read/SearchSideEffects.js", {
+  namedExports: {
+    commitSearchSideEffects: async () => null
+  }
+});
+
+mock.module("../../lib/memory/read/Reranker.js", {
+  namedExports: {
+    isRerankerAvailable: () => false,
+    rerank             : async () => null
+  }
+});
+
+const { FragmentIndex }       = await import("../../lib/memory/FragmentIndex.js");
+const { FragmentReader }      = await import("../../lib/memory/read/FragmentReader.js");
+const { FragmentSearch }      = await import("../../lib/memory/read/FragmentSearch.js");
+const { fetchGraphNeighbors } = await import("../../lib/memory/read/GraphNeighborSearch.js");
+const { LinkStore }           = await import("../../lib/memory/link/LinkStore.js");
+const { MemoryRecaller }      = await import("../../lib/memory/processors/MemoryRecaller.js");
+
+const NOW = new Date().toISOString();
+
+function fragment(overrides) {
+  return {
+    id         : "fragment",
+    content    : "scope isolation content",
+    topic      : "scope-isolation",
+    keywords   : ["scope-isolation"],
+    type       : "fact",
+    importance : 0.9,
+    created_at : NOW,
+    valid_to   : null,
+    agent_id   : "agent-a",
+    workspace  : "ws-a",
+    ...overrides
+  };
+}
+
+function idsOf(result) {
+  return new Set(result.fragments.map(item => item.id));
+}
+
+async function runHotCacheSearch(includePeerAgents) {
+  const index = new FragmentIndex();
+  const rows = [
+    fragment({ id: "own" }),
+    fragment({ id: "peer", agent_id: "agent-b" }),
+    fragment({ id: "global", agent_id: "default", workspace: null }),
+    fragment({ id: "cross-workspace", workspace: "ws-b" })
+  ];
+
+  for (const row of rows) {
+    await index.index(row, null, null);
+    await index.cacheFragment(row.id, row, null);
+  }
+
+  const search = Object.create(FragmentSearch.prototype);
+  search.index = index;
+  search.store = {
+    searchByKeywords: async () => [],
+    searchByTopic   : async () => [],
+    getByIds        : async () => [],
+    incrementAccess : () => {},
+    touchLinked     : async () => {}
+  };
+
+  const query = {
+    keywords   : ["scope-isolation"],
+    workspace  : "ws-a",
+    agentId    : "agent-a",
+    tokenBudget: 5000
+  };
+  if (includePeerAgents !== undefined) {
+    query.includePeerAgents = includePeerAgents;
+  }
+
+  return search.search(query);
+}
+
+beforeEach(() => {
+  redisRef.current = createRedisMock();
+  vectorQueries = [];
+  graphQueries  = [];
+  graphRows     = [];
+  linkedRows    = [];
+});
+
+describe("Hot Cache 최종 결과 agent/workspace 격리", () => {
+  it("includePeerAgents 생략 시 peer와 다른 workspace를 차단하고 default 전역은 허용한다", async () => {
+    const result = await runHotCacheSearch(undefined);
+    assert.deepEqual(idsOf(result), new Set(["own", "global"]));
+  });
+
+  it("includePeerAgents=false 시 peer와 다른 workspace를 차단한다", async () => {
+    const result = await runHotCacheSearch(false);
+    assert.deepEqual(idsOf(result), new Set(["own", "global"]));
+  });
+
+  it("includePeerAgents=true 시 같은 workspace peer는 허용하되 다른 workspace는 차단한다", async () => {
+    const result = await runHotCacheSearch(true);
+    assert.deepEqual(idsOf(result), new Set(["own", "peer", "global"]));
+  });
+});
+
+describe("FragmentReader 검색 SELECT agent_id 가시성", () => {
+  it("SEARCH_COLS_BASE 경로가 Hot Cache에 저장할 agent_id를 반환한다", async () => {
+    const reader = new FragmentReader();
+    await reader.searchByKeywords(["scope-isolation"], { agentId: "agent-a" });
+
+    const { sql } = vectorQueries.at(-1);
+    const selectList = sql.slice(0, sql.indexOf("FROM agent_memory.fragments"));
+    assert.match(selectList, /\bf\.agent_id\b/);
+  });
+});
+
+describe("GraphNeighborSearch SQL 및 최종 RRF 격리", () => {
+  it("기본 SQL이 key_id에 더해 agent/workspace 조건과 결과 필드를 포함한다", async () => {
+    await fetchGraphNeighbors(
+      ["seed"],
+      10,
+      "agent-a",
+      ["key-1"],
+      { workspace: "ws-a", includePeerAgents: false }
+    );
+
+    const { sql, params } = graphQueries.at(-1);
+    assert.ok((sql.match(/f\.agent_id/g) ?? []).length >= 4);
+    assert.ok((sql.match(/f\.workspace/g) ?? []).length >= 4);
+    assert.ok((sql.match(/\(f\.agent_id = \$5 OR f\.agent_id = 'default'\)/g) ?? []).length >= 2);
+    assert.ok((sql.match(/\(f\.workspace = \$6 OR f\.workspace IS NULL\)/g) ?? []).length >= 2);
+    assert.deepEqual(params, [["seed"], ["seed"], 10, ["key-1"], "agent-a", "ws-a"]);
+  });
+
+  it("includePeerAgents=true는 agent 조건만 생략하고 key_id/workspace 조건은 유지한다", async () => {
+    await fetchGraphNeighbors(
+      ["seed"],
+      10,
+      "agent-a",
+      ["key-1"],
+      { workspace: "ws-a", includePeerAgents: true }
+    );
+
+    const { sql, params } = graphQueries.at(-1);
+    assert.doesNotMatch(sql, /f\.agent_id = \$/);
+    assert.match(sql, /f\.key_id = ANY\(\$4::text\[\]\)/);
+    assert.match(sql, /\(f\.workspace = \$5 OR f\.workspace IS NULL\)/);
+    assert.deepEqual(params, [["seed"], ["seed"], 10, ["key-1"], "ws-a"]);
+  });
+
+  it("SQL mock이 범위 밖 행을 반환해도 RRF 병합 전에 scope가 다시 차단한다", async () => {
+    graphRows = [
+      fragment({ id: "graph-own" }),
+      fragment({ id: "graph-peer", agent_id: "agent-b" }),
+      fragment({ id: "graph-global", agent_id: "default", workspace: null }),
+      fragment({ id: "graph-cross-workspace", workspace: "ws-b" })
+    ];
+
+    const search = Object.create(FragmentSearch.prototype);
+    search._searchL2 = async () => [fragment({ id: "seed" })];
+    search._searchL3 = async () => [];
+
+    const sq = {
+      text             : "scope isolation",
+      agentId          : "agent-a",
+      keyId            : ["key-1"],
+      workspace        : "ws-a",
+      includePeerAgents: false,
+      minImportance    : 0
+    };
+    const combined = await search._buildTextRRF(
+      sq, [], [], false, [], "agent-a", ["key-1"], null, [], {}
+    );
+    const ids = new Set(combined.map(row => row.id));
+
+    assert.ok(ids.has("graph-own"));
+    assert.ok(ids.has("graph-global"));
+    assert.ok(!ids.has("graph-peer"));
+    assert.ok(!ids.has("graph-cross-workspace"));
+  });
+});
+
+describe("LinkStore SQL agent/workspace 격리", () => {
+  it("기본 SQL이 key_id에 더해 agent/workspace 조건과 결과 필드를 포함한다", async () => {
+    const store = new LinkStore();
+    await store.getLinkedFragments(
+      ["seed"],
+      null,
+      "agent-a",
+      ["key-1"],
+      { workspace: "ws-a", includePeerAgents: false }
+    );
+
+    const { sql, params } = vectorQueries.at(-1);
+    assert.ok((sql.match(/f\.agent_id/g) ?? []).length >= 4);
+    assert.ok((sql.match(/f\.workspace/g) ?? []).length >= 4);
+    assert.ok((sql.match(/\(f\.agent_id = \$3 OR f\.agent_id = 'default'\)/g) ?? []).length >= 2);
+    assert.ok((sql.match(/\(f\.workspace = \$4 OR f\.workspace IS NULL\)/g) ?? []).length >= 2);
+    assert.deepEqual(params, [["seed"], ["key-1"], "agent-a", "ws-a"]);
+  });
+
+  it("includePeerAgents=true는 agent 조건만 생략하고 key_id/workspace 조건은 유지한다", async () => {
+    const store = new LinkStore();
+    await store.getLinkedFragments(
+      ["seed"],
+      null,
+      "agent-a",
+      ["key-1"],
+      { workspace: "ws-a", includePeerAgents: true }
+    );
+
+    const { sql, params } = vectorQueries.at(-1);
+    assert.doesNotMatch(sql, /f\.agent_id = \$/);
+    assert.match(sql, /f\.key_id = ANY\(\$2\)/);
+    assert.match(sql, /\(f\.workspace = \$3 OR f\.workspace IS NULL\)/);
+    assert.deepEqual(params, [["seed"], ["key-1"], "ws-a"]);
+  });
+});
+
+function createRecaller(linkedFragments, capturedCalls) {
+  const base = fragment({ id: "base" });
+  const search = {
+    search: async () => ({
+      fragments : [{ ...base }],
+      totalTokens: 10,
+      searchPath: "L2",
+      count     : 1
+    })
+  };
+  const store = {
+    getLinkedFragments: async (...args) => {
+      capturedCalls.push(args);
+      return linkedFragments.map(row => ({ ...row }));
+    }
+  };
+
+  return new MemoryRecaller({ store, search });
+}
+
+describe("MemoryRecaller 기본 includeLinks 최종 병합 격리", () => {
+  const linkCandidates = [
+    fragment({ id: "linked-own" }),
+    fragment({ id: "linked-peer", agent_id: "agent-b" }),
+    fragment({ id: "linked-global", agent_id: "default", workspace: null }),
+    fragment({ id: "linked-cross-workspace", workspace: "ws-b" })
+  ];
+
+  it("기본값은 peer/다른 workspace를 차단하고 opts를 저장소에 전달한다", async () => {
+    const calls    = [];
+    const recaller = createRecaller(linkCandidates, calls);
+    const result   = await recaller.recall({
+      agentId  : "agent-a",
+      workspace: "ws-a",
+      keywords : ["scope-isolation"]
+    });
+
+    assert.deepEqual(idsOf(result), new Set(["base", "linked-own", "linked-global"]));
+    assert.deepEqual(calls[0][4], {
+      workspace         : "ws-a",
+      includePeerAgents : false
+    });
+  });
+
+  it("includePeerAgents=true는 같은 workspace peer만 허용하고 전역 파편도 유지한다", async () => {
+    const calls    = [];
+    const recaller = createRecaller(linkCandidates, calls);
+    const result   = await recaller.recall({
+      agentId          : "agent-a",
+      workspace        : "ws-a",
+      keywords         : ["scope-isolation"],
+      includePeerAgents: true
+    });
+
+    assert.deepEqual(
+      idsOf(result),
+      new Set(["base", "linked-own", "linked-peer", "linked-global"])
+    );
+    assert.deepEqual(calls[0][4], {
+      workspace         : "ws-a",
+      includePeerAgents : true
+    });
+  });
+});

--- a/tests/unit/recall-peer-agents.test.js
+++ b/tests/unit/recall-peer-agents.test.js
@@ -28,6 +28,7 @@ mock.module("../../lib/tools/db.js", {
 });
 
 const { FragmentReader } = await import("../../lib/memory/read/FragmentReader.js");
+const { FragmentStore }  = await import("../../lib/memory/write/FragmentStore.js");
 
 const AGENT_COND = /agent_id = \$\d+ OR (f\.)?agent_id = 'default'/;
 const PEER_COND  = /\$\d+::text IS NOT NULL/;
@@ -80,6 +81,23 @@ describe("FragmentReader includePeerAgents", () => {
   it("searchByTimeRange includePeerAgents=true면 격리 완화", async () => {
     await reader.searchByTimeRange("2026-01-01", "2026-02-01", { agentId: "a1", includePeerAgents: true });
     assert.doesNotMatch(lastSql(), AGENT_COND);
+  });
+
+  it("FragmentStore.getByIds가 includePeerAgents 옵션을 전달", async () => {
+    const store = new FragmentStore();
+    await store.getByIds(["f1"], "a1", null, [], { includePeerAgents: true });
+    assert.doesNotMatch(lastSql(), AGENT_COND);
+    assert.match(lastSql(), PEER_COND);
+  });
+
+  it("FragmentStore.searchBySemantic이 includePeerAgents 옵션을 전달", async () => {
+    const store = new FragmentStore();
+    const vec = new Array(4).fill(0.1);
+    await store.searchBySemantic(
+      vec, 5, 0.3, "a1", null, false, null, null, null, false, true
+    );
+    assert.doesNotMatch(lastSql(), AGENT_COND);
+    assert.match(lastSql(), PEER_COND);
   });
 
   it("includePeerAgents=true여도 keyId 테넌트 필터는 유지", async () => {


### PR DESCRIPTION
## 관련 이슈

Refs #23

이 PR은 #23의 세 증상 중 원인이 소스에서 직접 확인되고 작은 변경으로 검증 가능한 두 범위를 수정합니다. 서버 재기동 후 protocol mismatch 건은 당시 요청 헤더와 복원 세션 상태가 없어 이번 PR에 포함하지 않았습니다.

## 변경 요약

1. `context()`의 anchor 조회에 workspace 스코프를 적용했습니다.
   - 호출 인자의 `workspace`가 우선합니다.
   - 없으면 인증 키의 `_defaultWorkspace`를 사용합니다.
   - workspace가 정해진 경우 같은 workspace와 전역(`workspace IS NULL`) anchor만 주입합니다.
   - workspace가 없으면 기존처럼 모든 workspace anchor를 허용합니다.

2. `includePeerAgents`가 검색 경로에 따라 유실되던 저장소 파사드 위임을 수정했습니다.
   - L1 ID cache miss를 보충하는 `getByIds(..., opts)` 경로
   - L3 semantic의 마지막 `includePeerAgents` 인자

3. `fragment_history`에도 명시적인 `includePeerAgents` opt-in을 추가했습니다.
   - 기본값 `false`의 기존 agent 격리는 유지합니다.
   - `true`일 때 같은 API key 스코프의 peer agent 파편 이력을 조회할 수 있습니다.
   - API key 테넌트 경계는 그대로 유지합니다.

## 원인

`ContextBuilder.build()`은 `workspace = params.workspace ?? params._defaultWorkspace ?? null`을 계산해 non-anchor core recall에는 전달했지만, anchor 전용 SQL에는 전달하지 않았습니다. 따라서 `is_anchor=true` 행은 `is_anchor`, `valid_to`, key 조건만으로 전역 선택됐습니다.

또한 reader 계층에는 peer-agent 완화 인자가 있었지만 `FragmentStore` 파사드가 `getByIds`의 옵션 객체와 `searchBySemantic`의 마지막 인자를 버리고 있었습니다. `fragment_history`는 해당 옵션을 스키마에 노출하거나 `getHistory → getById`로 전달하지 않았습니다.

## 실측 근거 요약

2026-07-24 배포 인스턴스에서 다음을 확인했습니다. 인증값은 포함하지 않았습니다.

- `api_keys`, `api_key_groups`, `api_key_group_members`: 모두 0건
- 전체 fragment 362건의 `key_id`: 모두 NULL
- `context(workspace="mcps")`에서 `holo-tcg-player` workspace의 영구 anchor 6건이 그대로 주입됨
- 반면 non-anchor core/working memory 구성은 `workspace="mcps"`에 반응함
- `fragment_history`에서 조회되지 않은 활성 파편 6건의 `agent_id`: codex 5건, codex-desktop 1건
- 같은 조건의 가시 대조군 3건의 `agent_id`: 모두 default
- `frag-83c2a22fc2336eea`는 이미 `valid_to`가 설정된 정상 supersede 행이므로 증거에서 제외
- `frag-dcab193a36c4513a`의 활성 상태 관찰은 14:01Z 이전이며, 이후 승인된 14:01:53Z 정리 배치에서 은퇴 처리됨

## 테스트

Windows 샌드박스의 프로세스 격리 제약 때문에 Node 테스트 러너는 `--test-isolation=none`으로 각 파일을 독립 실행했습니다. 의존성 lifecycle 스크립트도 `spawn EPERM`이어서 lockfile 설치는 `npm ci --ignore-scripts`로 완료했습니다.

- `context-anchor-limit.test.js`의 `ContextBuilder 앵커 주입`: 5/5 통과
- `fragment-history.test.js`: 3/3 통과
- `recall-peer-agents.test.js`: 10/10 통과
- `context-builder.test.js`: 12/12 통과
- `context-structured.test.js`: 8/8 통과
- `workspace-isolation.test.js`: 7/7 통과
- 합계: 45/45 통과
- 변경된 구현/테스트 8개 파일 ESLint: 통과

## 미포함 범위

서버 재기동 후 구세션이 `-32000 Protocol version mismatch`만 반환하는 문제는 #23에 원인 후보를 기록했습니다. upstream에는 세션 자동 복구와 negotiated version 검증이 함께 존재하므로, 재현 당시 `MCP-Protocol-Version` 헤더 및 Redis 복원 세션의 `negotiatedVersion`을 확보한 뒤 별도 수정하는 편이 안전하다고 판단했습니다.
