### PR TITLE
재기동 후 stale negotiatedVersion으로 세션이 영구 400이 되는 문제 수정

### DIFF
--- a/lib/handlers/mcp-handler.js
+++ b/lib/handlers/mcp-handler.js
@@ -8,7 +8,7 @@
 
 import { ACCESS_KEY, PORT, RATE_LIMIT_WINDOW_MS, REDIS_ENABLED, SESSION_TTL_MS, SUPPORTED_PROTOCOL_VERSIONS } from "../config.js";
 import { getRateLimitUsageCached } from "./_ratelimit-cache.js";
-import { recordHttpRequest, recordTenantIsolationBlocked, recordSessionRecovery, recordSession404, recordOriginRejected, recordProtocolVersionRejected, recordInitializeIpRateLimited } from "../metrics.js";
+import { recordHttpRequest, recordTenantIsolationBlocked, recordSessionRecovery, recordSession404, recordOriginRejected, recordProtocolVersionRejected, recordProtocolVersionReanchored, recordInitializeIpRateLimited } from "../metrics.js";
 import { readJsonBody } from "../utils.js";
 import { sendJSON } from "../compression.js";
 import {
@@ -118,7 +118,22 @@ export function injectSessionContext(msg, ctx) {
  * @returns {Promise<object>}
  */
 async function _resolveExistingSession(req, res, sessionId, msg) {
-  const validation = await validateStreamableSession(sessionId);
+  const protoHeader        = req.headers["mcp-protocol-version"];
+  const fallbackProtoValue = protoHeader || "2025-03-26";
+  /**
+   * 검토 결함 수정: 재앵커링에 쓰는 값은 반드시 지원 목록 통과 후여야 한다.
+   * fallbackProtoValue는 아직 검증되지 않은 raw 헤더값이다 — 이 값을 그대로
+   * validateStreamableSession/createStreamableSessionWithId에 넘기면, 실제
+   * 지원 여부 검사(_validateProtocolVersion, 이 함수보다 나중에 실행됨)가
+   * 400으로 거부하기 전에 이미 세션 상태·Redis·Prometheus label(무한 카디널리티
+   * 위험)에 미검증 값이 새겨진다. 미지원이면 undefined를 넘겨 재앵커링 자체를
+   * 건너뛰고, 요청은 기존 경로(아래 _validateProtocolVersion)에서 그대로 400
+   * 거부되게 한다.
+   */
+  const reanchorProtoValue = SUPPORTED_PROTOCOL_VERSIONS.includes(fallbackProtoValue)
+    ? fallbackProtoValue
+    : undefined;
+  const validation = await validateStreamableSession(sessionId, reanchorProtoValue);
 
   if (!validation.valid) {
     /** Session not found / expired 시 인증 유효 여부 확인 후 자동 복구 */
@@ -146,7 +161,13 @@ async function _resolveExistingSession(req, res, sessionId, msg) {
         const sessionDefaultWorkspace = authResult.defaultWorkspace ?? null;
         const sessionMode             = _resolveMode(req, msg, authResult.defaultMode ?? null, sessionKeyId);
 
-        /** 동일 sessionId로 복구 (클라이언트 데이터 보존) */
+        /**
+         * 동일 sessionId로 복구 (클라이언트 데이터 보존).
+         * negotiatedVersion을 현재 요청의 헤더 값(없으면 "2025-03-26")으로 즉시
+         * 채워 null 공백을 없앤다 (계약 R2 — 자동복구 경로). reanchorProtoValue는
+         * 이미 지원 목록 검사를 통과한 값이거나 undefined(→ 함수 기본값 null)이므로
+         * 미지원 값이 새 세션에 새겨질 수 없다.
+         */
         await createStreamableSessionWithId(
           sessionId,
           true,
@@ -154,7 +175,8 @@ async function _resolveExistingSession(req, res, sessionId, msg) {
           sessionGroupKeyIds,
           sessionPermissions,
           sessionDefaultWorkspace,
-          sessionMode
+          sessionMode,
+          reanchorProtoValue
         );
         recordSessionRecovery("same_id_success");
         logInfo(`[Streamable] Session recovered with same-id: ${sessionId} (keyId: ${authResult.keyId ?? "master"})`);
@@ -308,10 +330,17 @@ async function _validateProtocolVersion(req, res, msg, sessionId) {
     logInfo(`[Protocol] MCP-Protocol-Version header missing, falling back to 2025-03-26 for session ${sessionId?.slice(0, 8)}...`);
   } else {
     const session = streamableSessions.get(sessionId);
-    if (session?.negotiatedVersion && session.negotiatedVersion !== protoHeader) {
-      recordProtocolVersionRejected(protoHeader);
-      await sendJSON(res, 400, jsonRpcError(msg?.id ?? null, -32000, "Protocol version mismatch"), req);
-      return { rejected: true };
+    if (session && session.negotiatedVersion !== protoHeader) {
+      /**
+       * C3 자가치유(계약 R1): 세션 negotiatedVersion과 헤더가 달라도 거부하지 않고
+       * 헤더 값으로 재앵커링한 뒤 통과시킨다. MCP 스펙상 협상값 재사용은 SHOULD이며
+       * 서버가 이를 MUST로 승격해 거부할 근거가 없다(계약 §1 F1~F4). 공식 SDK의
+       * validateProtocolVersion도 지원 목록 검사만 하고 협상값 대조는 하지 않는다.
+       */
+      const fromVersion = session.negotiatedVersion ?? "null";
+      session.negotiatedVersion = protoHeader;
+      recordProtocolVersionReanchored(fromVersion, protoHeader);
+      logInfo(`[Protocol] Reanchored negotiatedVersion ${fromVersion} → ${protoHeader} for session ${sessionId?.slice(0, 8)}...`);
     }
   }
 
@@ -332,11 +361,25 @@ async function _validateProtocolVersion(req, res, msg, sessionId) {
 async function _dispatchAndRespond(req, res, msg, sessionId, sessionKeyId, sessionMode, startTime) {
   const { kind, response } = await dispatchJsonRpc(msg, { keyId: sessionKeyId, mode: sessionMode });
 
-  /** 2c-3: initialize 응답에서 negotiatedVersion을 세션에 저장 */
+  /**
+   * 2c-3 / 계약 R3: initialize 응답에서 negotiatedVersion을 세션에 저장하고,
+   * REDIS_ENABLED 시 즉시 영속한다. 이전에는 다음 요청의 TTL 갱신 저장까지
+   * 지연되어 그 사이 재기동하면 Redis에 stale(null) 값이 남는 공백이 있었다.
+   */
   if (msg.method === "initialize" && kind !== "accepted" && response?.result?.protocolVersion) {
     const session = streamableSessions.get(sessionId);
     if (session) {
       session.negotiatedVersion = response.result.protocolVersion;
+
+      if (REDIS_ENABLED) {
+        const persistable = { ...session };
+        delete persistable.getSseResponse;
+        delete persistable.setSseResponse;
+        delete persistable.close;
+        delete persistable._restoredFromRedis;
+        const remainingTtlSec = Math.max(Math.ceil((session.expiresAt - Date.now()) / 1000), 60);
+        await saveSessionToRedis(sessionId, persistable, remainingTtlSec);
+      }
     }
   }
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -409,11 +409,25 @@ export const originRejectedTotal = new prometheus.Counter({
   registers : [register]
 });
 
-/** 프로토콜 버전 거부 카운터 (지원하지 않는 MCP-Protocol-Version 헤더) */
+/**
+ * 프로토콜 버전 거부 카운터 (C4 전용: 지원하지 않는 MCP-Protocol-Version 헤더).
+ *
+ * 세션 negotiatedVersion과의 불일치(구 C3)는 더 이상 거부하지 않고 재앵커링하므로
+ * (계약 R1), 이 카운터는 SUPPORTED_PROTOCOL_VERSIONS 목록에 없는 값에만 증가한다.
+ * 재앵커링 이벤트는 protocolVersionReanchoredTotal로 별도 집계한다.
+ */
 export const protocolVersionRejectedTotal = new prometheus.Counter({
   name      : "mcp_protocol_version_rejected_total",
-  help      : "Total number of requests rejected due to unsupported MCP-Protocol-Version header",
+  help      : "Total number of requests rejected due to unsupported MCP-Protocol-Version header (C4 only)",
   labelNames: ["version"],
+  registers : [register]
+});
+
+/** 프로토콜 버전 재앵커링 카운터 (세션 negotiatedVersion을 헤더 값으로 자가치유) */
+export const protocolVersionReanchoredTotal = new prometheus.Counter({
+  name      : "mcp_protocol_version_reanchored_total",
+  help      : "Total number of session negotiatedVersion self-heal reanchors",
+  labelNames: ["from", "to"],
   registers : [register]
 });
 
@@ -434,12 +448,22 @@ export function recordOriginRejected(origin) {
 }
 
 /**
- * 프로토콜 버전 거부 기록
+ * 프로토콜 버전 거부 기록 (C4 전용 — 지원 목록에 없는 값)
  *
  * @param {string} version - 거부된 MCP-Protocol-Version 헤더 값
  */
 export function recordProtocolVersionRejected(version) {
   protocolVersionRejectedTotal.inc({ version: version || "unknown" });
+}
+
+/**
+ * 프로토콜 버전 재앵커링 기록 (세션 negotiatedVersion 불일치 자가치유, 계약 R1/R2)
+ *
+ * @param {string} from - 재앵커링 이전 negotiatedVersion ("null" 문자열 포함 가능)
+ * @param {string} to   - 재앵커링 이후 negotiatedVersion (요청 헤더 값)
+ */
+export function recordProtocolVersionReanchored(from, to) {
+  protocolVersionReanchoredTotal.inc({ from: from || "null", to: to || "unknown" });
 }
 
 /**

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -7,7 +7,7 @@
  */
 
 import crypto            from "crypto";
-import { SESSION_TTL_MS, REDIS_ENABLED, CACHE_SESSION_TTL, SSE_HEARTBEAT_INTERVAL_MS, SSE_MAX_HEARTBEAT_FAILURES, IDLE_REFLECT_HOURS } from "./config.js";
+import { SESSION_TTL_MS, REDIS_ENABLED, CACHE_SESSION_TTL, SSE_HEARTBEAT_INTERVAL_MS, SSE_MAX_HEARTBEAT_FAILURES, IDLE_REFLECT_HOURS, SUPPORTED_PROTOCOL_VERSIONS } from "./config.js";
 import {
   saveSession as saveSessionToRedis,
   getSession as getSessionFromRedis,
@@ -15,7 +15,7 @@ import {
 } from "./redis.js";
 import { autoReflect } from "./memory/processors/AutoReflect.js";
 import { logInfo } from "./logger.js";
-import { recordSessionIdleReflect } from "./metrics.js";
+import { recordSessionIdleReflect, recordProtocolVersionReanchored } from "./metrics.js";
 
 /** Streamable HTTP 세션 저장소 */
 export const streamableSessions = new Map();
@@ -32,8 +32,12 @@ export const legacySseSessions  = new Map();
  * @param {string[]|null} groupKeyIds
  * @param {string[]|null} permissions
  * @param {string|null} defaultWorkspace
+ * @param {string|null} mode
+ * @param {string|null} negotiatedVersion 자동복구 경로에서 즉시 재앵커링할 프로토콜 버전
+ *                                        (계약 R2). 일반 신규 세션(initialize 전)은
+ *                                        협상 전이므로 null을 유지한다.
  */
-export async function createStreamableSessionWithId(sessionId, authenticated = false, keyId = null, groupKeyIds = null, permissions = null, defaultWorkspace = null, mode = null) {
+export async function createStreamableSessionWithId(sessionId, authenticated = false, keyId = null, groupKeyIds = null, permissions = null, defaultWorkspace = null, mode = null, negotiatedVersion = null) {
   let sseResponse         = null;
   let heartbeat           = null;
   const now                 = Date.now();
@@ -50,7 +54,7 @@ export async function createStreamableSessionWithId(sessionId, authenticated = f
     expiresAt          : now + SESSION_TTL_MS,
     lastAccessedAt     : now,
     lastReflectedAt    : null,
-    negotiatedVersion  : null
+    negotiatedVersion  : negotiatedVersion ?? null
   };
 
   const session = {
@@ -157,8 +161,17 @@ export async function createStreamableSession(authenticated = false, keyId = nul
 
 /**
  * Streamable HTTP 세션 검증 (TTL 체크)
+ *
+ * @param {string} sessionId
+ * @param {string} [requestedProtocolVersion] 호출자(POST 핸들러)가 현재 요청의
+ *   MCP-Protocol-Version 헤더 값(없으면 "2025-03-26")을 전달하면, Redis에서 복원된
+ *   세션의 negotiatedVersion을 즉시 그 값으로 재앵커링한다(계약 R2). 인자를 생략한
+ *   호출자(GET/DELETE 등 프로토콜 버전 검증을 하지 않는 경로)는 기존 동작을 그대로 유지한다.
+ *   호출자는 반드시 SUPPORTED_PROTOCOL_VERSIONS 통과 후의 값만 넘겨야 한다 —
+ *   미지원 값이 세션·Redis·재앵커링 메트릭 label에 새겨지는 것을 막기 위해
+ *   아래에서도 동일 검사를 한 번 더 방어적으로 수행한다(검토 결함 수정).
  */
-export async function validateStreamableSession(sessionId) {
+export async function validateStreamableSession(sessionId, requestedProtocolVersion) {
   let session             = streamableSessions.get(sessionId);
 
   // 메모리에 없으면 Redis에서 조회 시도
@@ -167,9 +180,15 @@ export async function validateStreamableSession(sessionId) {
 
     if (redisSession) {
       /**
-       * Redis 복원 세션: 인증 상태(keyId, authenticated)만 복원.
+       * Redis 복원 세션: `...redisSession` 스프레드로 저장돼 있던 전체 필드를 복원한다
+       * — keyId·authenticated뿐 아니라 negotiatedVersion을 포함한 모든 필드가 대상이다.
+       * (구 주석은 "인증 상태만 복원"이라 적었으나 사실이 아니었다 — 계약 R9)
        * SSE 연결은 TCP 소켓 기반이므로 프로세스 경계를 넘어 복구 불가.
        * POST /mcp (JSON-RPC)는 정상 처리, GET /mcp (SSE 스트림)은 재연결 필요.
+       *
+       * negotiatedVersion은 재기동 이전 값이 그대로 되살아나 stale할 수 있다
+       * (구버전에서는 initialize 직후 즉시 영속되지 않아 null인 경우도 있었다 — R3).
+       * requestedProtocolVersion이 주어지면 아래에서 현재 요청 기준으로 재앵커링한다.
        */
       const now           = Date.now();
       session             = {
@@ -188,10 +207,21 @@ export async function validateStreamableSession(sessionId) {
         }
       };
 
+      if (requestedProtocolVersion !== undefined && SUPPORTED_PROTOCOL_VERSIONS.includes(requestedProtocolVersion)) {
+        const fromVersion         = session.negotiatedVersion ?? "null";
+        session.negotiatedVersion = requestedProtocolVersion;
+        if (fromVersion !== session.negotiatedVersion) {
+          recordProtocolVersionReanchored(fromVersion, session.negotiatedVersion);
+          logInfo(`[Protocol] Reanchored restored session ${sessionId.slice(0, 8)}... negotiatedVersion ${fromVersion} → ${session.negotiatedVersion}`);
+        }
+      }
+
       streamableSessions.set(sessionId, session);
 
       // Redis 복원 직후 TTL 갱신 (슬라이딩 윈도우 연장)
-      const persistableRestore = { ...redisSession, lastAccessedAt: now, expiresAt: now + SESSION_TTL_MS };
+      // session(재앵커링 반영본) 기준으로 저장 — redisSession을 그대로 쓰면 위에서
+      // 재앵커링한 negotiatedVersion이 이 저장에서 유실된다.
+      const persistableRestore = { ...session };
       delete persistableRestore.getSseResponse;
       delete persistableRestore.setSseResponse;
       delete persistableRestore.close;

--- a/tests/unit/mcp-protocol-reanchor-integration.test.js
+++ b/tests/unit/mcp-protocol-reanchor-integration.test.js
@@ -1,0 +1,354 @@
+/**
+ * MCP protocol-version 자가치유 — 실제 핸들러 통합 테스트
+ *
+ * 작성자: codex (계약 위임 구현)
+ * 작성일: 2026-07-26
+ *
+ * 배경 (findings/anchormind-protocol-mismatch-contract-20260725.md):
+ *   서버 재기동 시 in-memory streamableSessions Map은 비워지지만 Redis 세션은
+ *   preserveRedis:true로 살아남는다. 이때 Redis 복원 경로(lib/sessions.js
+ *   validateStreamableSession)는 `...redisSession` 스프레드로 전 필드를 복원하므로
+ *   stale negotiatedVersion이 되살아난다. 그 값이 클라이언트의
+ *   MCP-Protocol-Version 헤더와 다르면 구 코드는 이후 모든 요청을 HTTP 400
+ *   -32000 "Protocol version mismatch"로 영구 거부했다 — 재initialize 전까지
+ *   회복 불가능한 장애였다.
+ *
+ * 이 파일은 tests/unit/mcp-protocol-version.test.js / mcp-404-session.test.js의
+ * "분기 로직을 복사한 순수 함수" 검증의 공백을 메운다: 실제 initialize →
+ * (fake) Redis 저장 → in-memory Map 초기화(재기동 시뮬레이션) → 실제 Redis 복원 →
+ * 실제 protocol validation까지 mcp-handler.js / sessions.js의 진짜 코드로 수행한다.
+ *
+ * 모킹 대상은 lib/redis.js 단 하나뿐이다 (실제 ioredis 연결 없이 세션 저장/조회/
+ * 삭제를 인메모리로 재현). saveSession/getSession/deleteSession/bindTokenToSession/
+ * getSessionIdByToken은 sessions.js·mcp-handler.js가 상수 redisClient를 직접
+ * 참조하므로 `__setRedisClientForTest`로는 가로챌 수 없다 — 모듈 자체를 mock한다.
+ * 인증은 master key(MEMENTO_ACCESS_KEY) 경로를 사용해 DB(admin/ApiKeyStore.js,
+ * getGroupKeyIds)와 rate-limit 캐시(getRateLimitUsageCached)가 전혀 호출되지
+ * 않도록 한다(keyId=null이면 두 경로 모두 가드로 스킵됨) — 그 외 로직은 전부 실물이다.
+ */
+
+import { describe, it, mock, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+
+/**
+ * config.js는 최초 import 시점의 process.env를 그대로 캡처하므로, 이 값들은
+ * 반드시 아래의 동적 import보다 먼저 설정되어야 한다 (정적 import는 호이스팅되어
+ * 파일 최상단에서 먼저 평가되므로, config.js를 정적 import하는 대신 이후 모든
+ * 관련 모듈을 동적 import로 불러온다).
+ */
+process.env.MEMENTO_ACCESS_KEY      = "reanchor-it-master-key-20260726";
+process.env.REDIS_ENABLED           = "true";
+process.env.MEMENTO_METRICS_DEFAULT = "off";
+
+/** ------------------------------------------------------------------
+ *  인메모리 fake Redis — lib/redis.js 전체를 대체한다.
+ *  세션 관련 5개 함수(getSession/saveSession/deleteSession/bindTokenToSession/
+ *  getSessionIdByToken)만 실제와 동등하게 동작하고, 나머지는 mcp-handler.js의
+ *  import 그래프(jsonrpc.js → tools/index.js → 각 도구 구현)가 링크 단계에서
+ *  요구하는 이름을 전부 채우기 위한 무해한 스텁이다.
+ * ------------------------------------------------------------------ */
+const _store = new Map();
+
+function _rawGet(key) {
+  const entry = _store.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    _store.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+function _rawSet(key, value, ttlSeconds) {
+  _store.set(key, { value, expiresAt: Date.now() + Math.max(ttlSeconds, 1) * 1000 });
+}
+
+const fakeRedisClient = {
+  status: "fake",
+  get: async () => null, set: async () => "OK", setex: async () => "OK", del: async () => 0,
+  lpush: async () => 0, rpush: async () => 0, rpop: async () => null, lpop: async () => null,
+  rpoplpush: async () => null, lrem: async () => 0,
+  keys: async () => [], scan: async () => ["0", []],
+  llen: async () => 0, expire: async () => 1, ping: async () => "PONG",
+  hset: async () => 1, hgetall: async () => ({}),
+  quit: async () => {}, disconnect: () => {},
+  on: () => {}, once: () => {}, removeListener: () => {}
+};
+
+const fakeRedisModule = {
+  redisClient: fakeRedisClient,
+  async checkRedisHealth() { return { healthy: true, message: "fake" }; },
+  getSessionKey: (id) => `session:${id}`,
+  getOAuthCodeKey: (c) => `oauth:code:${c}`,
+  getOAuthTokenKey: (t) => `oauth:token:${t}`,
+  getDocCacheKey: (p) => `cache:doc:${p}`,
+  getDbCacheKey: () => "cache:db:fake",
+  getTokenSessionKey: (t) => `token:session:${t}`,
+
+  /** 세션 저장/조회/삭제 — 이 테스트가 실제로 의존하는 부분 */
+  async saveSession(sessionId, sessionData, ttlSeconds) {
+    _rawSet(`session:${sessionId}`, JSON.stringify(sessionData), ttlSeconds);
+    return true;
+  },
+  async getSession(sessionId) {
+    const raw = _rawGet(`session:${sessionId}`);
+    return raw ? JSON.parse(raw) : null;
+  },
+  async deleteSession(sessionId) {
+    _store.delete(`session:${sessionId}`);
+    return true;
+  },
+  async extendSessionTTL() { return true; },
+
+  /** 토큰-세션 역인덱스 */
+  async bindTokenToSession(tokenKey, sessionId, ttlSeconds) {
+    _rawSet(`token:session:${tokenKey}`, sessionId, ttlSeconds);
+    return true;
+  },
+  async getSessionIdByToken(tokenKey) {
+    return _rawGet(`token:session:${tokenKey}`);
+  },
+  async unbindToken(tokenKey) {
+    _store.delete(`token:session:${tokenKey}`);
+    return true;
+  },
+
+  /** OAuth / 캐싱 / 큐 — 이 테스트 경로에서는 호출되지 않는 무해한 스텁 */
+  async saveOAuthCode() { return true; },
+  async consumeOAuthCode() { return null; },
+  async saveOAuthToken() { return true; },
+  async getOAuthToken() { return null; },
+  async deleteOAuthToken() { return true; },
+  async extendOAuthToken() { return true; },
+  async cacheDocument() { return true; },
+  async getCachedDocument() { return null; },
+  async invalidateDocumentCache() { return true; },
+  async cacheDbQuery() { return true; },
+  async getCachedDbQuery() { return null; },
+  async invalidateCacheByPattern() { return 0; },
+  async pushToQueue() { return true; },
+  async pushToQueuePriority() { return true; },
+  async popFromQueue() { return null; },
+  __setRedisClientForTest() {},
+  async popFromQueueReliable() { return null; },
+  async ackQueueItem() { return true; },
+  async requeueProcessing() { return 0; },
+  async pushToQueueDead() { return true; },
+  async getQueueLength() { return 0; },
+  async closeRedis() {},
+  async connectRedis() {},
+  async disconnectRedis() {},
+  async setBatchJobStatus() { return true; },
+  async getBatchJobStatus() { return null; }
+};
+
+mock.module("../../lib/redis.js", {
+  namedExports: fakeRedisModule,
+  defaultExport: fakeRedisClient
+});
+
+const { handleMcpPost }                         = await import("../../lib/handlers/mcp-handler.js");
+const { streamableSessions }                    = await import("../../lib/sessions.js");
+const { protocolVersionReanchoredTotal }        = await import("../../lib/metrics.js");
+
+const MASTER_KEY   = process.env.MEMENTO_ACCESS_KEY;
+const rateLimiter  = { allow: () => true };
+const SUPPORTED    = ["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"];
+
+/** ------------------------------------------------------------------
+ *  req/res 페이크 — handleMcpPost가 요구하는 최소 인터페이스
+ * ------------------------------------------------------------------ */
+
+function makeReq(bodyObj, headers = {}) {
+  const req = new Readable({ read() {} });
+  req.push(Buffer.from(JSON.stringify(bodyObj)));
+  req.push(null);
+  req.headers = { host: "localhost:57332", authorization: `Bearer ${MASTER_KEY}`, ...headers };
+  req.method  = "POST";
+  req.url     = "/mcp";
+  req.socket  = { remoteAddress: "127.0.0.1", encrypted: false };
+  return req;
+}
+
+function makeRes() {
+  const headers = {};
+  const res = {
+    statusCode: 200,
+    body      : undefined,
+    setHeader(name, value) { headers[name.toLowerCase()] = value; },
+    getHeader(name) { return headers[name.toLowerCase()]; },
+    end(data) { res.body = data; },
+    writeHead(code, hdrs) {
+      res.statusCode = code;
+      if (hdrs) for (const [k, v] of Object.entries(hdrs)) headers[k.toLowerCase()] = v;
+    },
+    _headers: headers
+  };
+  return res;
+}
+
+function parseBody(res) {
+  if (res.body === undefined || res.body === null) return null;
+  try { return JSON.parse(res.body); } catch { return res.body; }
+}
+
+let _seq = 0;
+
+async function initializeSession({ protocolVersion = "2025-03-26", headers = {} } = {}) {
+  const req = makeReq(
+    { jsonrpc: "2.0", id: ++_seq, method: "initialize", params: { protocolVersion, capabilities: {}, clientInfo: { name: "it-client", version: "1.0" } } },
+    headers
+  );
+  const res = makeRes();
+  await handleMcpPost(req, res, process.hrtime.bigint(), rateLimiter);
+  assert.strictEqual(res.statusCode, 200, `initialize 실패: ${res.body}`);
+  const sessionId = res._headers["mcp-session-id"];
+  assert.ok(sessionId, "MCP-Session-Id 헤더가 있어야 한다");
+  return { sessionId, body: parseBody(res) };
+}
+
+async function callToolsList(sessionId, headers = {}) {
+  const req = makeReq({ jsonrpc: "2.0", id: ++_seq, method: "tools/list", params: {} }, { "mcp-session-id": sessionId, ...headers });
+  const res = makeRes();
+  await handleMcpPost(req, res, process.hrtime.bigint(), rateLimiter);
+  return { res, body: parseBody(res) };
+}
+
+/* ==================================================================== */
+/*  테스트                                                                */
+/* ==================================================================== */
+
+describe("MCP protocol-version 자가치유 — 실제 핸들러 통합 테스트", () => {
+
+  beforeEach(() => {
+    /**
+     * 각 테스트를 완전히 격리한다. master key 인증은 항상 동일한 토큰 문자열이므로
+     * deriveTokenKey의 토큰-세션 재사용 기능(claude.ai 커넥터 대응, _createInitializeSession
+     * 참고)이 그대로 두면 테스트마다 같은 세션을 재사용해버려 "매 initialize는 새
+     * 세션"이라는 이 테스트 스위트의 전제가 깨진다. in-memory Map과 fake Redis를
+     * 모두 비워 매 테스트가 독립적인 세션에서 출발하도록 한다.
+     */
+    streamableSessions.clear();
+    _store.clear();
+  });
+
+  it("I3 (핵심 회귀): negotiatedVersion=2025-03-26 세션에 헤더 2025-06-18로 tools/call → 200 (구 400 mismatch 폐기, R1)", async () => {
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-03-26" });
+
+    const { res, body } = await callToolsList(sessionId, { "mcp-protocol-version": "2025-06-18" });
+
+    assert.strictEqual(res.statusCode, 200, `mismatch reanchor 실패: ${JSON.stringify(body)}`);
+    assert.ok(Array.isArray(body?.result?.tools), "tools/list 결과가 정상 반환되어야 한다");
+
+    const session = streamableSessions.get(sessionId);
+    assert.strictEqual(session.negotiatedVersion, "2025-06-18", "세션이 헤더 값으로 재앵커링되어야 한다");
+  });
+
+  it("I2: 재기동 시뮬레이션(streamableSessions.clear 대응 — 개별 delete) 후 동일 sessionId 호출 → 200 (Redis 보존)", async () => {
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-06-18" });
+
+    /** 재기동 시뮬레이션: in-memory Map만 비운다. Redis(fake)는 그대로 보존된다. */
+    streamableSessions.delete(sessionId);
+
+    const { res, body } = await callToolsList(sessionId, { "mcp-protocol-version": "2025-06-18" });
+    assert.strictEqual(res.statusCode, 200, `재기동 후 세션 복원 실패: ${JSON.stringify(body)}`);
+  });
+
+  it("I13: Redis에 stale negotiatedVersion(null)이 저장돼 있어도 복원 시 요청 헤더로 즉시 재앵커링된다 (R2)", async () => {
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-03-26" });
+
+    /** 구버전 버그 재현: Redis에 저장된 negotiatedVersion을 인위적으로 null로 되돌린다 */
+    const raw = await fakeRedisModule.getSession(sessionId);
+    raw.negotiatedVersion = null;
+    await fakeRedisModule.saveSession(sessionId, raw, 3600);
+
+    streamableSessions.delete(sessionId); // 재기동 시뮬레이션
+
+    const { res } = await callToolsList(sessionId, { "mcp-protocol-version": "2025-11-25" });
+    assert.strictEqual(res.statusCode, 200);
+
+    const restored = streamableSessions.get(sessionId);
+    assert.strictEqual(restored.negotiatedVersion, "2025-11-25", "Redis 복원 직후 헤더 값으로 재앵커링되어야 한다 (R2)");
+
+    const persisted = await fakeRedisModule.getSession(sessionId);
+    assert.strictEqual(persisted.negotiatedVersion, "2025-11-25", "재앵커링된 값이 Redis에도 즉시 반영되어야 한다");
+  });
+
+  it("검증 순서 결함 회귀: 재기동 복원 요청의 미지원 헤더는 400으로 거부되고, 거부 전에 세션/Redis/메트릭에 새겨지지 않는다", async () => {
+    /**
+     * 독립 재검토에서 확정된 결함: _resolveExistingSession이 검증 전 raw 헤더값
+     * (fallbackProtoValue)을 validateStreamableSession/createStreamableSessionWithId에
+     * 넘겼다. 실제 지원 여부 검사(_validateProtocolVersion)는 호출 순서상 그 뒤에
+     * 실행되므로, 미지원 값이 거부되기 *전에* 이미 세션 negotiatedVersion·Redis·
+     * Prometheus reanchor 메트릭 label에 새겨졌다(무한 카디널리티 위험 포함).
+     * 이 테스트는 세 가지 부작용이 전혀 발생하지 않음을 증명한다.
+     */
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-03-26" });
+
+    /** 재기동 시뮬레이션: in-memory Map만 비운다 — fake Redis는 "2025-03-26"을 보존 */
+    streamableSessions.delete(sessionId);
+
+    const before = await protocolVersionReanchoredTotal.get();
+    const totalBefore = before.values.reduce((sum, v) => sum + v.value, 0);
+
+    for (const badHeader of ["2099-01-01", "not-a-real-version"]) {
+      const { res, body } = await callToolsList(sessionId, { "mcp-protocol-version": badHeader });
+
+      // (a) 400으로 거부되어야 한다 (기존 _validateProtocolVersion 경로, 변경 없음)
+      assert.strictEqual(res.statusCode, 400, `${badHeader} → 400이어야 한다: ${JSON.stringify(body)}`);
+      assert.ok(body.error.message.includes("Unsupported protocol version"), body.error.message);
+
+      // (b) 세션 negotiatedVersion이 미지원 값으로 오염되지 않아야 한다
+      const session = streamableSessions.get(sessionId);
+      assert.ok(session, "거부되더라도 세션 자체는 복원되어 있어야 한다");
+      assert.notStrictEqual(session.negotiatedVersion, badHeader, "미지원 헤더 값이 세션에 새겨지면 안 된다");
+      assert.strictEqual(session.negotiatedVersion, "2025-03-26", "negotiatedVersion은 원래 값을 유지해야 한다");
+
+      // (b') fake Redis에도 미지원 값이 영속되면 안 된다
+      const persisted = await fakeRedisModule.getSession(sessionId);
+      assert.notStrictEqual(persisted?.negotiatedVersion, badHeader, "미지원 헤더 값이 Redis에 영속되면 안 된다");
+      assert.strictEqual(persisted?.negotiatedVersion, "2025-03-26", "Redis의 negotiatedVersion도 원래 값을 유지해야 한다");
+
+      // 다음 반복을 위해 다시 재기동 상태로 되돌린다 (in-memory만 비움)
+      streamableSessions.delete(sessionId);
+    }
+
+    // (c) reanchor 메트릭이 증가하지 않아야 한다 — 미지원 값으로 인한 label 카디널리티 오염 금지
+    const after = await protocolVersionReanchoredTotal.get();
+    const totalAfter = after.values.reduce((sum, v) => sum + v.value, 0);
+    assert.strictEqual(totalAfter, totalBefore, "미지원 헤더는 reanchor 메트릭을 증가시키면 안 된다");
+    assert.ok(
+      !after.values.some(v => v.labels.to === "2099-01-01" || v.labels.to === "not-a-real-version"),
+      "미지원 헤더 값이 reanchor 메트릭의 'to' label로 기록되면 안 된다 (카디널리티 오염 금지)"
+    );
+  });
+
+  it("R3: initialize 직후 negotiatedVersion이 Redis에 즉시 영속된다 (다음 요청까지 지연되지 않음)", async () => {
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-11-25" });
+    const persisted = await fakeRedisModule.getSession(sessionId);
+    assert.strictEqual(persisted.negotiatedVersion, "2025-11-25", "initialize 응답 직후 Redis에 즉시 저장되어야 한다");
+  });
+
+  it("A1 (회귀 가드): SUPPORTED_PROTOCOL_VERSIONS의 어떤 값도 400을 유발하지 않는다", async () => {
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-03-26" });
+    for (const ver of SUPPORTED) {
+      const { res, body } = await callToolsList(sessionId, { "mcp-protocol-version": ver });
+      assert.notStrictEqual(res.statusCode, 400, `${ver} → 400 발생: ${JSON.stringify(body)}`);
+    }
+  });
+
+  it("C1: 세션 부재(Session not found) + 인증 유효 → 200 자동복구 (클라이언트에는 투명)", async () => {
+    const req = makeReq(
+      { jsonrpc: "2.0", id: ++_seq, method: "tools/list", params: {} },
+      { "mcp-session-id": "ghost-but-authenticated-session", "mcp-protocol-version": "2025-06-18" }
+    );
+    const res = makeRes();
+    await handleMcpPost(req, res, process.hrtime.bigint(), rateLimiter);
+
+    assert.strictEqual(res.statusCode, 200, `자동복구 실패: ${res.body}`);
+    const session = streamableSessions.get("ghost-but-authenticated-session");
+    assert.ok(session, "세션이 생성되어야 한다");
+    assert.strictEqual(session.negotiatedVersion, "2025-06-18", "자동복구 세션도 헤더 값으로 즉시 채워져야 한다 (R2)");
+  });
+});

--- a/tests/unit/mcp-protocol-version.test.js
+++ b/tests/unit/mcp-protocol-version.test.js
@@ -3,16 +3,23 @@
  *
  * 작성자: 최진호
  * 작성일: 2026-04-17
+ * 수정일: 2026-07-26 — 계약 findings/anchormind-protocol-mismatch-contract-20260725.md
+ *         반영. negotiatedVersion 불일치를 거부(400)하던 옛 계약을 폐기하고,
+ *         헤더 값으로 재앵커링하는 자가치유(C3)로 교체했다 (R1).
+ *         구 TC5는 폐기된 계약(mismatch→400)을 고정하고 있어 반드시 교체 대상이었다.
  *
  * 검증 대상 (MCP 2025-06-18 스펙 준수):
  *  1. initialize 응답 후 negotiatedVersion이 세션에 저장됨
  *  2. 헤더 없음 → 2025-03-26 fallback (통과)
  *  3. 헤더=세션 version 일치 → 통과
- *  4. 헤더=미지원 version → 400
- *  5. 헤더=지원 version이지만 세션 version과 다름 → 400
+ *  4. 헤더=미지원 version → 400 ("Unsupported protocol version")
+ *  5. 헤더=지원 version이지만 세션 version과 다름 → 200 + 재앵커링 (구 400 계약 폐기, R1)
  *  6. initialize 요청은 헤더 검증 생략
  *
- * 인프라 의존성 없이 순수 함수로 분기 로직을 재현하여 검증한다.
+ * 인프라 의존성 없이 순수 함수로 분기 로직을 재현하여 검증한다. 실제 핸들러
+ * (mcp-handler.js)·세션(sessions.js)을 호출하는 진짜 통합 테스트는
+ * tests/unit/mcp-protocol-reanchor-integration.test.js 참고 — 그 파일이
+ * red(수정 전 400) → green(수정 후 200) 전환의 실측 증거를 담당한다.
  */
 
 import { describe, it } from "node:test";
@@ -28,30 +35,43 @@ const SUPPORTED_PROTOCOL_VERSIONS = [
 const FALLBACK_VERSION = "2025-03-26";
 
 /**
- * handleMcpPost의 Protocol-Version 검증 분기 로직 순수 함수 재현.
+ * handleMcpPost의 Protocol-Version 검증 분기 로직 순수 함수 재현
+ * (mcp-handler.js `_validateProtocolVersion`, 계약 R1 반영. 메시지 확장/data
+ * 봉투는 R4 — 별도 브랜치 agent/mcp-error-recovery-contract 범위).
  *
  * @param {object} params
- * @param {string}          params.method              - JSON-RPC 메서드
+ * @param {string}           params.method            - JSON-RPC 메서드
  * @param {string|undefined} params.protoHeader        - req.headers["mcp-protocol-version"] 값
- * @param {string|null}     params.sessionNegotiated   - session.negotiatedVersion 값
- * @returns {{ status: number, message: string|null, effectiveVersion: string|null }}
+ * @param {string|null|undefined} params.sessionNegotiated
+ *   - 세션의 negotiatedVersion 값. `undefined`는 "세션 자체가 없음"(재앵커링 스킵),
+ *     `null`은 "세션은 있으나 아직 협상되지 않음"(재앵커링 대상)을 의미한다.
+ * @returns {{ status: number, message: string|null, effectiveVersion: string|null,
+ *             reanchored: boolean, negotiatedVersionAfter: string|null }}
  */
 function checkProtocolVersion({ method, protoHeader, sessionNegotiated }) {
   if (method === "initialize") {
-    return { status: 200, message: null, effectiveVersion: null };
+    return { status: 200, message: null, effectiveVersion: null, reanchored: false, negotiatedVersionAfter: sessionNegotiated ?? null };
   }
 
   const effectiveVersion = protoHeader || FALLBACK_VERSION;
 
   if (!SUPPORTED_PROTOCOL_VERSIONS.includes(effectiveVersion)) {
-    return { status: 400, message: "Unsupported protocol version", effectiveVersion };
+    return { status: 400, message: "Unsupported protocol version", effectiveVersion, reanchored: false, negotiatedVersionAfter: sessionNegotiated ?? null };
   }
 
-  if (protoHeader && sessionNegotiated && sessionNegotiated !== protoHeader) {
-    return { status: 400, message: "Protocol version mismatch", effectiveVersion };
+  if (!protoHeader) {
+    return { status: 200, message: null, effectiveVersion, reanchored: false, negotiatedVersionAfter: sessionNegotiated ?? null };
   }
 
-  return { status: 200, message: null, effectiveVersion };
+  /**
+   * R1 자가치유: 세션이 존재하고(sessionNegotiated !== undefined) negotiatedVersion이
+   * 헤더와 다르면(null이었던 경우 포함) 거부하지 않고 헤더 값으로 재앵커링한다.
+   */
+  if (sessionNegotiated !== undefined && sessionNegotiated !== protoHeader) {
+    return { status: 200, message: null, effectiveVersion, reanchored: true, negotiatedVersionAfter: protoHeader };
+  }
+
+  return { status: 200, message: null, effectiveVersion, reanchored: false, negotiatedVersionAfter: sessionNegotiated ?? protoHeader };
 }
 
 /**
@@ -69,7 +89,7 @@ function simulateInitializeVersionStore(responseProtocolVersion) {
 /*  테스트 케이스                                                       */
 /* ================================================================== */
 
-describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3)", () => {
+describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3 + 계약 R1)", () => {
 
   it("TC1: initialize 응답 후 negotiatedVersion이 세션에 저장됨", () => {
     const session = simulateInitializeVersionStore("2025-06-18");
@@ -89,9 +109,10 @@ describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3)", () => {
     });
     assert.strictEqual(result.status, 200);
     assert.strictEqual(result.effectiveVersion, FALLBACK_VERSION);
+    assert.strictEqual(result.reanchored, false, "헤더 없는 fallback 경로는 재앵커링하지 않는다");
   });
 
-  it("TC3: 헤더=세션 version 일치 → 통과", () => {
+  it("TC3: 헤더=세션 version 일치 → 통과 (재앵커링 없음)", () => {
     const result = checkProtocolVersion({
       method           : "tools/call",
       protoHeader      : "2025-06-18",
@@ -99,6 +120,7 @@ describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3)", () => {
     });
     assert.strictEqual(result.status, 200);
     assert.strictEqual(result.message, null);
+    assert.strictEqual(result.reanchored, false);
   });
 
   it("TC4: 헤더=미지원 version → 400", () => {
@@ -111,14 +133,16 @@ describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3)", () => {
     assert.strictEqual(result.message, "Unsupported protocol version");
   });
 
-  it("TC5: 헤더=지원 version이지만 세션 version과 다름 → 400", () => {
+  it("TC5: 헤더=지원 version이지만 세션 version과 다름 → 200 + 재앵커링 (계약 R1, 구 400 폐기)", () => {
     const result = checkProtocolVersion({
       method           : "tools/call",
       protoHeader      : "2025-03-26",
       sessionNegotiated: "2025-06-18"
     });
-    assert.strictEqual(result.status, 400);
-    assert.strictEqual(result.message, "Protocol version mismatch");
+    assert.strictEqual(result.status, 200, "구 계약(400 mismatch)은 폐기되었다 — 거부하지 않는다");
+    assert.strictEqual(result.message, null);
+    assert.strictEqual(result.reanchored, true, "세션 negotiatedVersion을 헤더 값으로 재앵커링해야 한다");
+    assert.strictEqual(result.negotiatedVersionAfter, "2025-03-26", "재앵커링 이후 값은 헤더 값이어야 한다");
   });
 
   it("TC6: initialize 요청은 헤더 검증 생략 (항상 통과)", () => {
@@ -130,13 +154,15 @@ describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3)", () => {
     assert.strictEqual(result.status, 200, "initialize는 헤더 검증 대상에서 제외");
   });
 
-  it("TC7: 헤더=지원 version + 세션 negotiatedVersion null → 통과", () => {
+  it("TC7: 헤더=지원 version + 세션 negotiatedVersion null → 통과 + 재앵커링 (null 공백 해소, R1/R2)", () => {
     const result = checkProtocolVersion({
       method           : "tools/list",
       protoHeader      : "2025-06-18",
       sessionNegotiated: null   // initialize 직후 아직 저장 안 된 경우
     });
     assert.strictEqual(result.status, 200);
+    assert.strictEqual(result.reanchored, true, "null negotiatedVersion도 헤더 값으로 채워야 한다");
+    assert.strictEqual(result.negotiatedVersionAfter, "2025-06-18");
   });
 
   it("TC8: 모든 SUPPORTED_PROTOCOL_VERSIONS가 개별적으로 통과", () => {
@@ -147,6 +173,33 @@ describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3)", () => {
         sessionNegotiated: ver
       });
       assert.strictEqual(result.status, 200, `${ver} should pass`);
+    }
+  });
+
+  /* ================================================================ */
+  /*  회귀 가드 (계약 §4 A1/A2)                                          */
+  /* ================================================================ */
+
+  it("A1: SUPPORTED_PROTOCOL_VERSIONS의 어떤 값도 400을 유발하지 않는다 (세션 미존재 포함)", () => {
+    for (const ver of SUPPORTED_PROTOCOL_VERSIONS) {
+      const withSession = checkProtocolVersion({ method: "tools/call", protoHeader: ver, sessionNegotiated: "2024-11-05" });
+      const noSession    = checkProtocolVersion({ method: "tools/call", protoHeader: ver, sessionNegotiated: undefined });
+      assert.notStrictEqual(withSession.status, 400, `${ver} + 세션 있음 → 400 금지`);
+      assert.notStrictEqual(noSession.status,    400, `${ver} + 세션 없음 → 400 금지`);
+    }
+  });
+
+  it("A2: 400 응답의 message는 항상 'Unsupported protocol version' 부분문자열을 포함한다", () => {
+    const unsupportedSamples = ["2099-01-01", "1999-01-01", "not-a-version", ""];
+    for (const bad of unsupportedSamples) {
+      const result = checkProtocolVersion({ method: "tools/call", protoHeader: bad, sessionNegotiated: null });
+      if (bad === "") {
+        /** 빈 문자열 헤더는 protoHeader가 falsy이므로 fallback(2025-03-26, 지원됨)으로 통과 */
+        assert.strictEqual(result.status, 200);
+        continue;
+      }
+      assert.strictEqual(result.status, 400, `${bad}는 미지원이므로 400이어야 한다`);
+      assert.ok(result.message.includes("Unsupported protocol version"), `메시지: ${result.message}`);
     }
   });
 });


### PR DESCRIPTION
## 관련 이슈

Refs #23 (증상 3)

## 요약

서버 프로세스가 재기동되면, 재기동 이전에 initialize된 세션의 이후 모든 요청이
`HTTP 400` + `{"code":-32000,"message":"Protocol version mismatch"}`로 **영구 실패**합니다.
재initialize하면 복구되지만 클라이언트는 그 사실을 알 수 없어 세션이 사실상 죽습니다.

원인은 복구 경로가 두 개인데 한쪽만 `negotiatedVersion`을 초기화한다는 점입니다.

## 원인

재기동 시 in-memory `streamableSessions` Map은 비워지지만 Redis 세션은
`preserveRedis: true`로 보존됩니다(`server.js`). 이후 복구 경로가 갈립니다.

| 경로 | 함수 | `negotiatedVersion` |
|---|---|---|
| 자동복구 | `createStreamableSessionWithId` | `null`로 초기화 → 무해 |
| **Redis 복원** | `sessions.js` `{...redisSession}` 스프레드 | **stale 값 그대로 부활** |

Redis 복원 경로는 `createStreamableSessionWithId`를 거치지 않으므로 null 초기화가
적용되지 않습니다. 복원된 구 협상값이 클라이언트의 `MCP-Protocol-Version` 헤더와
다르면 `mcp-handler.js`의 대조 분기가 이후 **모든** 요청을 400으로 거부합니다.

이 결함이 눈에 띄지 않았던 이유가 두 가지 있습니다.

1. 스프레드 바로 위 주석이 "인증 상태(keyId, authenticated)만 복원"이라고 적혀
   있으나 실제로는 전 필드를 복원합니다. 주석이 사실과 다릅니다.
2. 관련 테스트가 모두 순수 함수·모의 객체 단위여서, "initialize → Redis 저장 →
   Map 초기화(재기동) → Redis 복원 → protocol validation"을 관통하는 테스트가
   없었습니다.

## 수정 방향 — 거부 대신 재앵커링

대조 자체를 제거하고 헤더 값으로 재앵커링하도록 바꿨습니다. 근거는 세 가지입니다.

1. **스펙**: 2025-06-18 / 2025-11-25 Transports는 `MCP-Protocol-Version`에 대해
   *"invalid or unsupported"* 인 경우에만 400을 MUST로 요구합니다. 클라이언트가
   협상값을 보내는 것은 `SHOULD`이며, 위반 시 서버 동작에 대한 규정이 없습니다.
   즉 "세션 협상값과 다름"은 스펙에 정의된 오류 케이스가 아닙니다.
2. **레퍼런스 구현**: 공식 TypeScript SDK(v1.29.0) 서버 트랜스포트의
   `validateProtocolVersion`은 지원 목록 검사만 하고 협상값 대조를 하지 않습니다.
3. **실효성**: `session.negotiatedVersion`은 이 거부 판정 외에 서버 어디에서도
   읽히지 않습니다(전체 검색 확인). 디스패치·툴 목록·응답 포맷 어느 것도 이 값에
   분기하지 않으며 보안 경계도 아닙니다.

지원 목록에 없는 값에 대한 400 거부는 **그대로 유지**했습니다(스펙 MUST).

## 변경 내용

- `mcp-handler.js` — 협상값 대조 거부를 제거하고, 헤더가 지원 목록에 있으면
  `session.negotiatedVersion`을 그 값으로 재앵커링한 뒤 통과시킵니다.
- `mcp-handler.js` / `sessions.js` — Redis 복원·자동복구 경로에서 세션의
  `negotiatedVersion`을 현재 요청 헤더 값(없으면 `2025-03-26`)으로 채워 null 공백과
  stale 값을 함께 제거합니다. 재앵커링에 쓰이는 값은 **반드시 `SUPPORTED_PROTOCOL_VERSIONS`
  검사를 통과한 것**이며, 미지원 값은 세션·Redis·메트릭 label 어디에도 도달하지 않습니다
  (검사 순서상 400 거부는 그 뒤에 일어나므로, 거부 전 부작용을 남기지 않도록 게이팅했습니다).
- `mcp-handler.js` — initialize 응답에서 `negotiatedVersion`을 세팅할 때 Redis에
  즉시 영속합니다. 기존에는 다음 요청의 TTL 갱신 저장까지 지연되어, 그 사이 재기동하면
  Redis에 stale 값이 남는 공백이 있었습니다.
- `sessions.js` — 사실과 다른 복원 주석을 실제 동작대로 수정했습니다.
- `metrics.js` — 재앵커링 관측용 `mcp_protocol_version_reanchored_total{from,to}`를
  추가했습니다. label 값은 지원 목록에 있는 버전 문자열로 한정되므로 카디널리티가 유계입니다.

## 테스트

실제 `handleMcpPost` / `sessions.js` 코드를 관통하는 통합 테스트를 추가했습니다
(`lib/redis.js`만 in-memory fake로 대체). 커버 범위:

- 재기동 시뮬레이션 후 stale 협상값 + 다른 헤더 → 200 (이 PR의 핵심 회귀)
- Redis 복원 시 `negotiatedVersion` 복원·재앵커링
- **미지원 헤더로 복원 요청 시 400 거부 + 세션/Redis 값 미오염 + 재앵커 메트릭 불변**
- 지원 목록의 어떤 값도 400을 유발하지 않음 / 400 message는 `Unsupported protocol version` 포함

기존 `mcp-protocol-version.test.js`의 해당 케이스는 새 동작에 맞게 교체했습니다.
(이 파일은 핸들러를 호출하지 않고 분기 로직을 복사한 순수 함수를 검증하는 구조라,
위 통합 테스트로 실제 경로를 보강했습니다.)

수정 전 코드에서 새 통합 테스트가 실패하고 수정 후 통과함을 확인했습니다.

## 범위에서 제외한 것

- **오류 응답 본문 개선**(`data`에 복구 가능 여부를 싣는 등)은 이 PR에 넣지 않았습니다.
  API 표면 추가라 별도로 제안드립니다.
- **명시적 `DELETE` 후 즉시 재사용**은 여전히 인증이 유효하면 자동복구됩니다. 완전히
  닫으려면 termination tombstone이 필요하고 `rotateSession`·heartbeat close·
  `cleanupExpiredSessions` 의미까지 영향을 받아, 이 PR의 범위 밖으로 두었습니다.

## 참고

Windows 환경에서 테스트를 실행했고, 프로세스 격리 제약 때문에 파일별
`--test-isolation=none`으로 독립 실행했습니다. 변경 모듈과 무관한 사전 존재 실패
(child process 생성이 차단되는 환경 이슈)는 diff 적용 전후가 동일함을 확인했습니다.
