### PR TITLE
[proposal] 세션·프로토콜·인증 4xx에 복구 가능 여부 계약 추가 (draft, #27 논의용)

### DIFF
--- a/lib/handlers/mcp-handler.js
+++ b/lib/handlers/mcp-handler.js
@@ -30,6 +30,61 @@ import { getAllowedOrigin, isOriginAllowed } from "./_common.js";
 import { getPreset } from "../memory/ModeRegistry.js";
 
 /**
+ * 4xx 오류 응답의 표준 data 봉투를 생성한다 (계약 §3-2, R6).
+ *
+ * `recoverable` + `recoveryAction` 두 필드만 읽으면 클라이언트가 영구 장애인지,
+ * 어떤 동작(재init/재인증/버전 교체)으로 복구 가능한지 한 번의 비교로 판별할 수 있다.
+ *
+ * reason 닫힌 열거값:
+ *  - "unsupported_protocol_version" : 지원 목록에 없는 MCP-Protocol-Version (C4)
+ *  - "authentication_required"      : 세션 부재 + 인증 무효 (C5a)
+ *  - "forbidden_tenant_mismatch"    : keyId 불일치로 세션 접근 거부 (C5b)
+ *  - "session_terminated"          : 세션 실제 종료(TTL 만료) (C5c)
+ *  - "session_required"            : 비-initialize 요청에 세션 ID 없음 (C6)
+ *
+ * recoveryAction 닫힌 열거값: "none" | "reinitialize" | "reauthenticate" | "change_protocol_version"
+ *
+ * @param {object} opts
+ * @returns {object}
+ */
+function buildErrorData({
+  reason,
+  recoverable,
+  recoveryAction,
+  sessionId = null,
+  receivedProtocolVersion = null,
+  negotiatedProtocolVersion = null,
+  supportedProtocolVersions = null,
+  retryAfterMs = 0,
+  specRef = null
+}) {
+  return {
+    reason,
+    recoverable,
+    recoveryAction,
+    sessionId,
+    receivedProtocolVersion,
+    negotiatedProtocolVersion,
+    supportedProtocolVersions,
+    retryAfterMs,
+    specRef
+  };
+}
+
+/**
+ * 401 응답용 WWW-Authenticate 헤더 값을 구성한다.
+ * `_createInitializeSession`와 `_resolveExistingSession`의 인증 실패 분기가 공유한다.
+ *
+ * @param {import('http').IncomingMessage} req
+ * @returns {string}
+ */
+function _buildWwwAuthenticateHeader(req) {
+  const proto   = req.headers["x-forwarded-proto"] || (req.socket.encrypted ? "https" : "http");
+  const baseUrl = `${proto}://${req.headers.host || `localhost:${PORT}`}`;
+  return `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`;
+}
+
+/**
  * 인증된 요청에서 토큰-세션 재사용용 캐시 키를 파생한다.
  * 우선순위: Authorization Bearer → memento-access-key → initialize.params.accessKey.
  * 토큰 원문은 저장하지 않고 sha256 단축 해시만 키로 사용한다. master 세션은 keyId가 null이므로
@@ -136,9 +191,16 @@ async function _resolveExistingSession(req, res, sessionId, msg) {
   const validation = await validateStreamableSession(sessionId, reanchorProtoValue);
 
   if (!validation.valid) {
-    /** Session not found / expired 시 인증 유효 여부 확인 후 자동 복구 */
-    const isRecoverable = validation.reason === "Session not found"
-                       || validation.reason === "Session expired";
+    /**
+     * C1/C5a: "Session not found"(메모리·Redis 어디에도 기록이 없음 — 재기동으로
+     * Redis 백업 없이 유실됐거나, 애초에 발급된 적 없는 sessionId)만 인증 기반
+     * 자동복구 대상이다. 인증이 유효하면 신뢰하고 복구(200), 무효하면 401.
+     *
+     * C5c: "Session expired"는 validateStreamableSession이 세션 레코드를 실제로
+     * 찾았고(메모리 또는 Redis) 그 TTL이 지났다는, 검증 가능한 "진짜 종료" 신호다.
+     * 인증 유효 여부와 무관하게 재initialize를 요구한다 (계약 §3-1 C5c).
+     */
+    const isRecoverable = validation.reason === "Session not found";
     if (isRecoverable) {
       const authResult = await validateAuthentication(req, msg);
       if (authResult.valid) {
@@ -150,7 +212,12 @@ async function _resolveExistingSession(req, res, sessionId, msg) {
           if (existingRedis && existingRedis.keyId !== incomingKeyId) {
             recordTenantIsolationBlocked("session_recover_keyid_mismatch");
             recordSessionRecovery("keyid_mismatch");
-            await sendJSON(res, 403, jsonRpcError(null, -32000, "Forbidden"), req);
+            await sendJSON(res, 403, jsonRpcError(null, -32000, "Forbidden", buildErrorData({
+              reason        : "forbidden_tenant_mismatch",
+              recoverable   : true,
+              recoveryAction: "reinitialize",
+              sessionId
+            })), req);
             return { done: true };
           }
         }
@@ -183,16 +250,26 @@ async function _resolveExistingSession(req, res, sessionId, msg) {
 
         return { done: false, sessionKeyId, sessionGroupKeyIds, sessionPermissions, sessionDefaultWorkspace, sessionMode };
       } else {
-        /** 2c-1: sessionId 있으나 Redis에 없고 인증 실패 → 404 Not Found */
+        /** C5a: 세션 부재 + 인증 무효 → 401 + WWW-Authenticate (계약 §3-1, 구 404 정정) */
         recordSessionRecovery("not_found");
-        recordSession404();
-        await sendJSON(res, 404, jsonRpcError(msg?.id ?? null, -32000, "Session not found"), req);
+        res.setHeader("WWW-Authenticate", _buildWwwAuthenticateHeader(req));
+        await sendJSON(res, 401, jsonRpcError(msg?.id ?? null, -32000, authResult.error || "Unauthorized", buildErrorData({
+          reason        : "authentication_required",
+          recoverable   : true,
+          recoveryAction: "reauthenticate",
+          sessionId
+        })), req);
         return { done: true };
       }
     } else {
-      /** 2c-1: Session expired 상태 → 404 Not Found */
+      /** C5c: 세션 실제 종료(TTL 만료) → 404 + -32001 (SDK 관행 정렬), 재initialize 필요 */
       recordSession404();
-      await sendJSON(res, 404, jsonRpcError(msg?.id ?? null, -32000, "Session not found"), req);
+      await sendJSON(res, 404, jsonRpcError(msg?.id ?? null, -32001, "Session not found", buildErrorData({
+        reason        : "session_terminated",
+        recoverable   : true,
+        recoveryAction: "reinitialize",
+        sessionId
+      })), req);
       return { done: true };
     }
   } else {
@@ -250,13 +327,14 @@ async function _createInitializeSession(req, res, msg) {
   const authCheck = await validateAuthentication(req, msg);
 
   if (!authCheck.valid) {
-    const proto   = req.headers["x-forwarded-proto"] || (req.socket.encrypted ? "https" : "http");
-    const baseUrl = `${proto}://${req.headers.host || `localhost:${PORT}`}`;
     res.statusCode = 401;
     res.setHeader("Content-Type", "application/json; charset=utf-8");
-    res.setHeader("WWW-Authenticate",
-      `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`);
-    res.end(JSON.stringify(jsonRpcError(msg.id ?? null, -32000, authCheck.error)));
+    res.setHeader("WWW-Authenticate", _buildWwwAuthenticateHeader(req));
+    res.end(JSON.stringify(jsonRpcError(msg.id ?? null, -32000, authCheck.error, buildErrorData({
+      reason        : "authentication_required",
+      recoverable   : true,
+      recoveryAction: "reauthenticate"
+    }))));
     return { done: true };
   }
 
@@ -321,8 +399,21 @@ async function _validateProtocolVersion(req, res, msg, sessionId) {
   const effectiveVersion = protoHeader || "2025-03-26";
 
   if (!SUPPORTED_PROTOCOL_VERSIONS.includes(effectiveVersion)) {
+    /** C4: 지원 목록에 없는 값만 거부한다 — 유일하게 스펙상 MUST 근거가 있는 케이스 */
     recordProtocolVersionRejected(protoHeader || "missing");
-    await sendJSON(res, 400, jsonRpcError(msg?.id ?? null, -32000, "Unsupported protocol version"), req);
+    const session = streamableSessions.get(sessionId);
+    const message = `Bad Request: Unsupported protocol version: ${effectiveVersion} ` +
+      `(supported versions: ${SUPPORTED_PROTOCOL_VERSIONS.join(", ")})`;
+    await sendJSON(res, 400, jsonRpcError(msg?.id ?? null, -32000, message, buildErrorData({
+      reason                   : "unsupported_protocol_version",
+      recoverable              : false,
+      recoveryAction           : "change_protocol_version",
+      sessionId,
+      receivedProtocolVersion  : protoHeader ?? null,
+      negotiatedProtocolVersion: session?.negotiatedVersion ?? null,
+      supportedProtocolVersions: SUPPORTED_PROTOCOL_VERSIONS,
+      specRef                  : "MCP Transports — MCP-Protocol-Version header"
+    })), req);
     return { rejected: true };
   }
 
@@ -494,7 +585,12 @@ export async function handleMcpPost(req, res, startTime, rateLimiter) {
       msg?.id ?? null,
       -32000,
       "Session required. Send an 'initialize' request first to create a session, " +
-      "then include the returned MCP-Session-Id header in subsequent requests."
+      "then include the returned MCP-Session-Id header in subsequent requests.",
+      buildErrorData({
+        reason        : "session_required",
+        recoverable   : true,
+        recoveryAction: "reinitialize"
+      })
     ), req);
     return;
   }

--- a/lib/handlers/mcp-handler.js
+++ b/lib/handlers/mcp-handler.js
@@ -8,7 +8,7 @@
 
 import { ACCESS_KEY, PORT, RATE_LIMIT_WINDOW_MS, REDIS_ENABLED, SESSION_TTL_MS, SUPPORTED_PROTOCOL_VERSIONS } from "../config.js";
 import { getRateLimitUsageCached } from "./_ratelimit-cache.js";
-import { recordHttpRequest, recordTenantIsolationBlocked, recordSessionRecovery, recordSession404, recordOriginRejected, recordProtocolVersionRejected, recordInitializeIpRateLimited } from "../metrics.js";
+import { recordHttpRequest, recordTenantIsolationBlocked, recordSessionRecovery, recordSession404, recordOriginRejected, recordProtocolVersionRejected, recordProtocolVersionReanchored, recordInitializeIpRateLimited } from "../metrics.js";
 import { readJsonBody } from "../utils.js";
 import { sendJSON } from "../compression.js";
 import {
@@ -118,7 +118,22 @@ export function injectSessionContext(msg, ctx) {
  * @returns {Promise<object>}
  */
 async function _resolveExistingSession(req, res, sessionId, msg) {
-  const validation = await validateStreamableSession(sessionId);
+  const protoHeader        = req.headers["mcp-protocol-version"];
+  const fallbackProtoValue = protoHeader || "2025-03-26";
+  /**
+   * 검토 결함 수정: 재앵커링에 쓰는 값은 반드시 지원 목록 통과 후여야 한다.
+   * fallbackProtoValue는 아직 검증되지 않은 raw 헤더값이다 — 이 값을 그대로
+   * validateStreamableSession/createStreamableSessionWithId에 넘기면, 실제
+   * 지원 여부 검사(_validateProtocolVersion, 이 함수보다 나중에 실행됨)가
+   * 400으로 거부하기 전에 이미 세션 상태·Redis·Prometheus label(무한 카디널리티
+   * 위험)에 미검증 값이 새겨진다. 미지원이면 undefined를 넘겨 재앵커링 자체를
+   * 건너뛰고, 요청은 기존 경로(아래 _validateProtocolVersion)에서 그대로 400
+   * 거부되게 한다.
+   */
+  const reanchorProtoValue = SUPPORTED_PROTOCOL_VERSIONS.includes(fallbackProtoValue)
+    ? fallbackProtoValue
+    : undefined;
+  const validation = await validateStreamableSession(sessionId, reanchorProtoValue);
 
   if (!validation.valid) {
     /** Session not found / expired 시 인증 유효 여부 확인 후 자동 복구 */
@@ -146,7 +161,13 @@ async function _resolveExistingSession(req, res, sessionId, msg) {
         const sessionDefaultWorkspace = authResult.defaultWorkspace ?? null;
         const sessionMode             = _resolveMode(req, msg, authResult.defaultMode ?? null, sessionKeyId);
 
-        /** 동일 sessionId로 복구 (클라이언트 데이터 보존) */
+        /**
+         * 동일 sessionId로 복구 (클라이언트 데이터 보존).
+         * negotiatedVersion을 현재 요청의 헤더 값(없으면 "2025-03-26")으로 즉시
+         * 채워 null 공백을 없앤다 (계약 R2 — 자동복구 경로). reanchorProtoValue는
+         * 이미 지원 목록 검사를 통과한 값이거나 undefined(→ 함수 기본값 null)이므로
+         * 미지원 값이 새 세션에 새겨질 수 없다.
+         */
         await createStreamableSessionWithId(
           sessionId,
           true,
@@ -154,7 +175,8 @@ async function _resolveExistingSession(req, res, sessionId, msg) {
           sessionGroupKeyIds,
           sessionPermissions,
           sessionDefaultWorkspace,
-          sessionMode
+          sessionMode,
+          reanchorProtoValue
         );
         recordSessionRecovery("same_id_success");
         logInfo(`[Streamable] Session recovered with same-id: ${sessionId} (keyId: ${authResult.keyId ?? "master"})`);
@@ -308,10 +330,17 @@ async function _validateProtocolVersion(req, res, msg, sessionId) {
     logInfo(`[Protocol] MCP-Protocol-Version header missing, falling back to 2025-03-26 for session ${sessionId?.slice(0, 8)}...`);
   } else {
     const session = streamableSessions.get(sessionId);
-    if (session?.negotiatedVersion && session.negotiatedVersion !== protoHeader) {
-      recordProtocolVersionRejected(protoHeader);
-      await sendJSON(res, 400, jsonRpcError(msg?.id ?? null, -32000, "Protocol version mismatch"), req);
-      return { rejected: true };
+    if (session && session.negotiatedVersion !== protoHeader) {
+      /**
+       * C3 자가치유(계약 R1): 세션 negotiatedVersion과 헤더가 달라도 거부하지 않고
+       * 헤더 값으로 재앵커링한 뒤 통과시킨다. MCP 스펙상 협상값 재사용은 SHOULD이며
+       * 서버가 이를 MUST로 승격해 거부할 근거가 없다(계약 §1 F1~F4). 공식 SDK의
+       * validateProtocolVersion도 지원 목록 검사만 하고 협상값 대조는 하지 않는다.
+       */
+      const fromVersion = session.negotiatedVersion ?? "null";
+      session.negotiatedVersion = protoHeader;
+      recordProtocolVersionReanchored(fromVersion, protoHeader);
+      logInfo(`[Protocol] Reanchored negotiatedVersion ${fromVersion} → ${protoHeader} for session ${sessionId?.slice(0, 8)}...`);
     }
   }
 
@@ -332,11 +361,25 @@ async function _validateProtocolVersion(req, res, msg, sessionId) {
 async function _dispatchAndRespond(req, res, msg, sessionId, sessionKeyId, sessionMode, startTime) {
   const { kind, response } = await dispatchJsonRpc(msg, { keyId: sessionKeyId, mode: sessionMode });
 
-  /** 2c-3: initialize 응답에서 negotiatedVersion을 세션에 저장 */
+  /**
+   * 2c-3 / 계약 R3: initialize 응답에서 negotiatedVersion을 세션에 저장하고,
+   * REDIS_ENABLED 시 즉시 영속한다. 이전에는 다음 요청의 TTL 갱신 저장까지
+   * 지연되어 그 사이 재기동하면 Redis에 stale(null) 값이 남는 공백이 있었다.
+   */
   if (msg.method === "initialize" && kind !== "accepted" && response?.result?.protocolVersion) {
     const session = streamableSessions.get(sessionId);
     if (session) {
       session.negotiatedVersion = response.result.protocolVersion;
+
+      if (REDIS_ENABLED) {
+        const persistable = { ...session };
+        delete persistable.getSseResponse;
+        delete persistable.setSseResponse;
+        delete persistable.close;
+        delete persistable._restoredFromRedis;
+        const remainingTtlSec = Math.max(Math.ceil((session.expiresAt - Date.now()) / 1000), 60);
+        await saveSessionToRedis(sessionId, persistable, remainingTtlSec);
+      }
     }
   }
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -409,11 +409,25 @@ export const originRejectedTotal = new prometheus.Counter({
   registers : [register]
 });
 
-/** 프로토콜 버전 거부 카운터 (지원하지 않는 MCP-Protocol-Version 헤더) */
+/**
+ * 프로토콜 버전 거부 카운터 (C4 전용: 지원하지 않는 MCP-Protocol-Version 헤더).
+ *
+ * 세션 negotiatedVersion과의 불일치(구 C3)는 더 이상 거부하지 않고 재앵커링하므로
+ * (계약 R1), 이 카운터는 SUPPORTED_PROTOCOL_VERSIONS 목록에 없는 값에만 증가한다.
+ * 재앵커링 이벤트는 protocolVersionReanchoredTotal로 별도 집계한다.
+ */
 export const protocolVersionRejectedTotal = new prometheus.Counter({
   name      : "mcp_protocol_version_rejected_total",
-  help      : "Total number of requests rejected due to unsupported MCP-Protocol-Version header",
+  help      : "Total number of requests rejected due to unsupported MCP-Protocol-Version header (C4 only)",
   labelNames: ["version"],
+  registers : [register]
+});
+
+/** 프로토콜 버전 재앵커링 카운터 (세션 negotiatedVersion을 헤더 값으로 자가치유) */
+export const protocolVersionReanchoredTotal = new prometheus.Counter({
+  name      : "mcp_protocol_version_reanchored_total",
+  help      : "Total number of session negotiatedVersion self-heal reanchors",
+  labelNames: ["from", "to"],
   registers : [register]
 });
 
@@ -434,12 +448,22 @@ export function recordOriginRejected(origin) {
 }
 
 /**
- * 프로토콜 버전 거부 기록
+ * 프로토콜 버전 거부 기록 (C4 전용 — 지원 목록에 없는 값)
  *
  * @param {string} version - 거부된 MCP-Protocol-Version 헤더 값
  */
 export function recordProtocolVersionRejected(version) {
   protocolVersionRejectedTotal.inc({ version: version || "unknown" });
+}
+
+/**
+ * 프로토콜 버전 재앵커링 기록 (세션 negotiatedVersion 불일치 자가치유, 계약 R1/R2)
+ *
+ * @param {string} from - 재앵커링 이전 negotiatedVersion ("null" 문자열 포함 가능)
+ * @param {string} to   - 재앵커링 이후 negotiatedVersion (요청 헤더 값)
+ */
+export function recordProtocolVersionReanchored(from, to) {
+  protocolVersionReanchoredTotal.inc({ from: from || "null", to: to || "unknown" });
 }
 
 /**

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -7,7 +7,7 @@
  */
 
 import crypto            from "crypto";
-import { SESSION_TTL_MS, REDIS_ENABLED, CACHE_SESSION_TTL, SSE_HEARTBEAT_INTERVAL_MS, SSE_MAX_HEARTBEAT_FAILURES, IDLE_REFLECT_HOURS } from "./config.js";
+import { SESSION_TTL_MS, REDIS_ENABLED, CACHE_SESSION_TTL, SSE_HEARTBEAT_INTERVAL_MS, SSE_MAX_HEARTBEAT_FAILURES, IDLE_REFLECT_HOURS, SUPPORTED_PROTOCOL_VERSIONS } from "./config.js";
 import {
   saveSession as saveSessionToRedis,
   getSession as getSessionFromRedis,
@@ -15,7 +15,7 @@ import {
 } from "./redis.js";
 import { autoReflect } from "./memory/processors/AutoReflect.js";
 import { logInfo } from "./logger.js";
-import { recordSessionIdleReflect } from "./metrics.js";
+import { recordSessionIdleReflect, recordProtocolVersionReanchored } from "./metrics.js";
 
 /** Streamable HTTP 세션 저장소 */
 export const streamableSessions = new Map();
@@ -32,8 +32,12 @@ export const legacySseSessions  = new Map();
  * @param {string[]|null} groupKeyIds
  * @param {string[]|null} permissions
  * @param {string|null} defaultWorkspace
+ * @param {string|null} mode
+ * @param {string|null} negotiatedVersion 자동복구 경로에서 즉시 재앵커링할 프로토콜 버전
+ *                                        (계약 R2). 일반 신규 세션(initialize 전)은
+ *                                        협상 전이므로 null을 유지한다.
  */
-export async function createStreamableSessionWithId(sessionId, authenticated = false, keyId = null, groupKeyIds = null, permissions = null, defaultWorkspace = null, mode = null) {
+export async function createStreamableSessionWithId(sessionId, authenticated = false, keyId = null, groupKeyIds = null, permissions = null, defaultWorkspace = null, mode = null, negotiatedVersion = null) {
   let sseResponse         = null;
   let heartbeat           = null;
   const now                 = Date.now();
@@ -50,7 +54,7 @@ export async function createStreamableSessionWithId(sessionId, authenticated = f
     expiresAt          : now + SESSION_TTL_MS,
     lastAccessedAt     : now,
     lastReflectedAt    : null,
-    negotiatedVersion  : null
+    negotiatedVersion  : negotiatedVersion ?? null
   };
 
   const session = {
@@ -157,8 +161,17 @@ export async function createStreamableSession(authenticated = false, keyId = nul
 
 /**
  * Streamable HTTP 세션 검증 (TTL 체크)
+ *
+ * @param {string} sessionId
+ * @param {string} [requestedProtocolVersion] 호출자(POST 핸들러)가 현재 요청의
+ *   MCP-Protocol-Version 헤더 값(없으면 "2025-03-26")을 전달하면, Redis에서 복원된
+ *   세션의 negotiatedVersion을 즉시 그 값으로 재앵커링한다(계약 R2). 인자를 생략한
+ *   호출자(GET/DELETE 등 프로토콜 버전 검증을 하지 않는 경로)는 기존 동작을 그대로 유지한다.
+ *   호출자는 반드시 SUPPORTED_PROTOCOL_VERSIONS 통과 후의 값만 넘겨야 한다 —
+ *   미지원 값이 세션·Redis·재앵커링 메트릭 label에 새겨지는 것을 막기 위해
+ *   아래에서도 동일 검사를 한 번 더 방어적으로 수행한다(검토 결함 수정).
  */
-export async function validateStreamableSession(sessionId) {
+export async function validateStreamableSession(sessionId, requestedProtocolVersion) {
   let session             = streamableSessions.get(sessionId);
 
   // 메모리에 없으면 Redis에서 조회 시도
@@ -167,9 +180,15 @@ export async function validateStreamableSession(sessionId) {
 
     if (redisSession) {
       /**
-       * Redis 복원 세션: 인증 상태(keyId, authenticated)만 복원.
+       * Redis 복원 세션: `...redisSession` 스프레드로 저장돼 있던 전체 필드를 복원한다
+       * — keyId·authenticated뿐 아니라 negotiatedVersion을 포함한 모든 필드가 대상이다.
+       * (구 주석은 "인증 상태만 복원"이라 적었으나 사실이 아니었다 — 계약 R9)
        * SSE 연결은 TCP 소켓 기반이므로 프로세스 경계를 넘어 복구 불가.
        * POST /mcp (JSON-RPC)는 정상 처리, GET /mcp (SSE 스트림)은 재연결 필요.
+       *
+       * negotiatedVersion은 재기동 이전 값이 그대로 되살아나 stale할 수 있다
+       * (구버전에서는 initialize 직후 즉시 영속되지 않아 null인 경우도 있었다 — R3).
+       * requestedProtocolVersion이 주어지면 아래에서 현재 요청 기준으로 재앵커링한다.
        */
       const now           = Date.now();
       session             = {
@@ -188,10 +207,21 @@ export async function validateStreamableSession(sessionId) {
         }
       };
 
+      if (requestedProtocolVersion !== undefined && SUPPORTED_PROTOCOL_VERSIONS.includes(requestedProtocolVersion)) {
+        const fromVersion         = session.negotiatedVersion ?? "null";
+        session.negotiatedVersion = requestedProtocolVersion;
+        if (fromVersion !== session.negotiatedVersion) {
+          recordProtocolVersionReanchored(fromVersion, session.negotiatedVersion);
+          logInfo(`[Protocol] Reanchored restored session ${sessionId.slice(0, 8)}... negotiatedVersion ${fromVersion} → ${session.negotiatedVersion}`);
+        }
+      }
+
       streamableSessions.set(sessionId, session);
 
       // Redis 복원 직후 TTL 갱신 (슬라이딩 윈도우 연장)
-      const persistableRestore = { ...redisSession, lastAccessedAt: now, expiresAt: now + SESSION_TTL_MS };
+      // session(재앵커링 반영본) 기준으로 저장 — redisSession을 그대로 쓰면 위에서
+      // 재앵커링한 negotiatedVersion이 이 저장에서 유실된다.
+      const persistableRestore = { ...session };
       delete persistableRestore.getSseResponse;
       delete persistableRestore.setSseResponse;
       delete persistableRestore.close;

--- a/tests/unit/mcp-404-session.test.js
+++ b/tests/unit/mcp-404-session.test.js
@@ -3,16 +3,22 @@
  *
  * 작성자: 최진호
  * 작성일: 2026-04-17
+ * 수정일: 2026-07-26 — 계약 findings/anchormind-protocol-mismatch-contract-20260725.md
+ *         반영 (R5). "세션 부재 + 인증 무효"는 404 → 401(+WWW-Authenticate)로 정정,
+ *         "세션 실제 종료(TTL 만료)"는 -32000 → -32001로 코드 정렬(SDK 관행).
+ *         두 케이스는 이전엔 동일하게 "Session not found" 404로 뭉뚱그려졌으나,
+ *         validateStreamableSession의 반환 reason으로 실제 구분 가능한 신호였다.
  *
  * 검증 대상 (MCP 2025-06-18 스펙 준수):
  *  1. sessionId 없음 + initialize → 세션 생성 (200)
  *  2. sessionId 없음 + 비-initialize → 400 (Session required)
  *  3. 유효 sessionId + 맞는 keyId → 기존 경로 (200)
- *  4. sessionId 있으나 Redis 없음 + 인증 실패 → 404 Not Found
- *  5. sessionId expired → 404 Not Found
+ *  4. sessionId 있으나 어디에도 기록 없음("Session not found") + 인증 실패 → 401 (구 404 정정)
+ *  5. sessionId 있고 레코드는 찾았으나 TTL 만료("Session expired") → 404 + -32001 (구 -32000 정정)
  *  6. sessionId + keyId 불일치 → 403 Forbidden
  *
- * 인프라 의존성 없이 순수 함수로 분기 로직을 재현하여 검증한다.
+ * 인프라 의존성 없이 순수 함수로 분기 로직을 재현하여 검증한다. 실제 핸들러를
+ * 호출하는 통합 테스트는 tests/unit/mcp-protocol-reanchor-integration.test.js 참고.
  */
 
 import { describe, it } from "node:test";
@@ -41,11 +47,12 @@ function fakeValidation(scenario) {
  * validateAuthentication 스텁
  */
 function fakeAuth(valid, keyId = null) {
-  return { valid, keyId, groupKeyIds: null, permissions: null, defaultWorkspace: null };
+  return { valid, keyId, groupKeyIds: null, permissions: null, defaultWorkspace: null, error: valid ? undefined : "Invalid or missing access key" };
 }
 
 /**
- * handleMcpPost의 세션 처리 분기 로직만 추출하여 순수 함수로 재현.
+ * handleMcpPost의 세션 처리 분기 로직만 추출하여 순수 함수로 재현
+ * (mcp-handler.js `_resolveExistingSession`, 계약 R5 반영).
  *
  * 반환값: { status, body }
  *   status: HTTP 상태 코드
@@ -56,8 +63,12 @@ function simulateSessionBranch({ sessionId, validationScenario, authValid, authK
     const validation = fakeValidation(validationScenario);
 
     if (!validation.valid) {
-      const isRecoverable = validation.reason === "Session not found"
-                         || validation.reason === "Session expired";
+      /**
+       * R5: "Session not found"만 인증 기반 자동복구 대상이다. "Session expired"는
+       * 레코드를 실제로 찾았고 TTL이 지났다는 검증 가능한 종료 신호이므로,
+       * 인증 유효 여부와 무관하게 404 + -32001(재initialize 필요)로 응답한다.
+       */
+      const isRecoverable = validation.reason === "Session not found";
 
       if (isRecoverable) {
         const authResult = fakeAuth(authValid, authKeyId);
@@ -70,12 +81,12 @@ function simulateSessionBranch({ sessionId, validationScenario, authValid, authK
           // 동일 ID 복구 성공 → 200 (세션 생성됨)
           return { status: 200, body: null, recovered: true };
         } else {
-          // 인증 실패 → 404
-          return { status: 404, body: { jsonrpc: "2.0", id: null, error: { code: -32000, message: "Session not found" } } };
+          // 인증 실패 → 401 (구 404 정정, C5a)
+          return { status: 401, body: { jsonrpc: "2.0", id: null, error: { code: -32000, message: authResult.error } } };
         }
       } else {
-        // 복구 불가 → 404
-        return { status: 404, body: { jsonrpc: "2.0", id: null, error: { code: -32000, message: "Session not found" } } };
+        // 세션 실제 종료(TTL 만료) → 404 + -32001 (C5c)
+        return { status: 404, body: { jsonrpc: "2.0", id: null, error: { code: -32001, message: "Session not found" } } };
       }
     }
 
@@ -106,7 +117,7 @@ function simulateSessionBranch({ sessionId, validationScenario, authValid, authK
 /*  테스트 케이스                                                       */
 /* ================================================================== */
 
-describe("MCP 세션 404 분기 (Phase 2c-1)", () => {
+describe("MCP 세션 404 분기 (Phase 2c-1 + 계약 R5)", () => {
 
   it("TC1: sessionId 없음 + initialize + 인증 성공 → 세션 생성 (200)", () => {
     const result = simulateSessionBranch({
@@ -146,25 +157,26 @@ describe("MCP 세션 404 분기 (Phase 2c-1)", () => {
     assert.strictEqual(result.recovered, undefined);
   });
 
-  it("TC4: sessionId 있으나 Redis 없음 + 인증 실패 → 404 Not Found", () => {
+  it("TC4: sessionId 있으나 기록 없음(Session not found) + 인증 실패 → 401 (구 404 정정, C5a)", () => {
     const result = simulateSessionBranch({
       sessionId          : "ghost-session-id",
       validationScenario : "not_found",
       authValid          : false,
       authKeyId          : null
     });
-    assert.strictEqual(result.status, 404);
-    assert.strictEqual(result.body.error.message, "Session not found");
+    assert.strictEqual(result.status, 401, "인증 무효는 404가 아니라 401이어야 한다");
+    assert.strictEqual(result.body.error.code, -32000);
   });
 
-  it("TC5: sessionId expired → 404 Not Found", () => {
+  it("TC5: sessionId 레코드는 찾았으나 TTL 만료(Session expired) → 404 + -32001 (C5c)", () => {
     const result = simulateSessionBranch({
       sessionId          : "expired-session-id",
       validationScenario : "expired",
-      authValid          : false,
-      authKeyId          : null
+      authValid          : true,   // 인증 유효 여부와 무관하게 종료 취급되어야 함을 함께 증명
+      authKeyId          : "key-1"
     });
     assert.strictEqual(result.status, 404);
+    assert.strictEqual(result.body.error.code, -32001, "SDK 관행에 맞춘 -32001 코드");
     assert.strictEqual(result.body.error.message, "Session not found");
   });
 

--- a/tests/unit/mcp-protocol-reanchor-integration.test.js
+++ b/tests/unit/mcp-protocol-reanchor-integration.test.js
@@ -148,7 +148,7 @@ mock.module("../../lib/redis.js", {
   defaultExport: fakeRedisClient
 });
 
-const { handleMcpPost }                         = await import("../../lib/handlers/mcp-handler.js");
+const { handleMcpPost, handleMcpDelete }        = await import("../../lib/handlers/mcp-handler.js");
 const { streamableSessions }                    = await import("../../lib/sessions.js");
 const { protocolVersionReanchoredTotal }        = await import("../../lib/metrics.js");
 
@@ -157,7 +157,7 @@ const rateLimiter  = { allow: () => true };
 const SUPPORTED    = ["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"];
 
 /** ------------------------------------------------------------------
- *  req/res 페이크 — handleMcpPost가 요구하는 최소 인터페이스
+ *  req/res 페이크 — handleMcpPost/handleMcpDelete가 요구하는 최소 인터페이스
  * ------------------------------------------------------------------ */
 
 function makeReq(bodyObj, headers = {}) {
@@ -166,6 +166,16 @@ function makeReq(bodyObj, headers = {}) {
   req.push(null);
   req.headers = { host: "localhost:57332", authorization: `Bearer ${MASTER_KEY}`, ...headers };
   req.method  = "POST";
+  req.url     = "/mcp";
+  req.socket  = { remoteAddress: "127.0.0.1", encrypted: false };
+  return req;
+}
+
+function makeDeleteReq(headers = {}) {
+  const req = new Readable({ read() {} });
+  req.push(null);
+  req.headers = { host: "localhost:57332", authorization: `Bearer ${MASTER_KEY}`, ...headers };
+  req.method  = "DELETE";
   req.url     = "/mcp";
   req.socket  = { remoteAddress: "127.0.0.1", encrypted: false };
   return req;
@@ -338,6 +348,34 @@ describe("MCP protocol-version 자가치유 — 실제 핸들러 통합 테스�
     }
   });
 
+  it("C4/A2: 미지원 프로토콜 버전 헤더 → 400 + data 봉투 (recoverable=false, change_protocol_version)", async () => {
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-03-26" });
+    const { res, body } = await callToolsList(sessionId, { "mcp-protocol-version": "1999-01-01" });
+
+    assert.strictEqual(res.statusCode, 400);
+    assert.ok(body.error.message.includes("Unsupported protocol version"), body.error.message);
+    assert.strictEqual(body.error.data.reason, "unsupported_protocol_version");
+    assert.strictEqual(body.error.data.recoverable, false);
+    assert.strictEqual(body.error.data.recoveryAction, "change_protocol_version");
+    assert.deepStrictEqual(body.error.data.supportedProtocolVersions, SUPPORTED);
+  });
+
+  it("C5a/I8: 세션 부재(Session not found) + 인증 무효 → 401 + WWW-Authenticate (구 404 정정, R5)", async () => {
+    const req = makeReq(
+      { jsonrpc: "2.0", id: ++_seq, method: "tools/list", params: {} },
+      { "mcp-session-id": "nonexistent-session-id-401", authorization: "Bearer WRONG-KEY" }
+    );
+    const res = makeRes();
+    await handleMcpPost(req, res, process.hrtime.bigint(), rateLimiter);
+
+    assert.strictEqual(res.statusCode, 401);
+    assert.ok(res._headers["www-authenticate"], "WWW-Authenticate 헤더가 있어야 한다");
+    const body = parseBody(res);
+    assert.strictEqual(body.error.data.reason, "authentication_required");
+    assert.strictEqual(body.error.data.recoverable, true);
+    assert.strictEqual(body.error.data.recoveryAction, "reauthenticate");
+  });
+
   it("C1: 세션 부재(Session not found) + 인증 유효 → 200 자동복구 (클라이언트에는 투명)", async () => {
     const req = makeReq(
       { jsonrpc: "2.0", id: ++_seq, method: "tools/list", params: {} },
@@ -350,5 +388,56 @@ describe("MCP protocol-version 자가치유 — 실제 핸들러 통합 테스�
     const session = streamableSessions.get("ghost-but-authenticated-session");
     assert.ok(session, "세션이 생성되어야 한다");
     assert.strictEqual(session.negotiatedVersion, "2025-06-18", "자동복구 세션도 헤더 값으로 즉시 채워져야 한다 (R2)");
+  });
+
+  it("C5c/I10-I12: TTL 만료 세션 재사용 → 404 + -32001, 재initialize 후 정상 (회복 전 구간 증명)", async () => {
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-03-26" });
+
+    /** TTL 만료 시뮬레이션: expiresAt을 과거로 되돌린다 (in-memory + fake Redis 양쪽) */
+    const inMemory = streamableSessions.get(sessionId);
+    inMemory.expiresAt = Date.now() - 1000;
+    const persisted = await fakeRedisModule.getSession(sessionId);
+    persisted.expiresAt = Date.now() - 1000;
+    await fakeRedisModule.saveSession(sessionId, persisted, 3600);
+
+    const { res, body } = await callToolsList(sessionId, { "mcp-protocol-version": "2025-03-26" });
+    assert.strictEqual(res.statusCode, 404);
+    assert.strictEqual(body.error.code, -32001, "SDK 관행에 맞춘 코드 (구 -32000 정정, R5)");
+    assert.strictEqual(body.error.message, "Session not found");
+    assert.strictEqual(body.error.data.reason, "session_terminated");
+    assert.strictEqual(body.error.data.recoverable, true);
+    assert.strictEqual(body.error.data.recoveryAction, "reinitialize");
+
+    /** 재initialize → 새 세션으로 정상 동작 (회복 전 구간) */
+    const { sessionId: newSessionId } = await initializeSession({ protocolVersion: "2025-03-26" });
+    assert.notStrictEqual(newSessionId, sessionId);
+    const { res: res2 } = await callToolsList(newSessionId, { "mcp-protocol-version": "2025-03-26" });
+    assert.strictEqual(res2.statusCode, 200);
+  });
+
+  it("DELETE 후 즉시 재사용 — 알려진 범위 제한: auth 유효 시 여전히 자동복구된다", async () => {
+    /**
+     * 계약 C5c는 "세션 실제 종료(DELETE 후 재사용) → 항상 404"를 요구하지만,
+     * 현재 구현은 이 정확한 리터럴 시나리오를 완전히 커버하지 못한다 — DELETE는
+     * 메모리·Redis 양쪽에서 레코드를 완전히 지우므로, 재사용 시 validateStreamableSession은
+     * "Session expired"가 아니라 "Session not found"를 반환하고, 이는 (의도적으로)
+     * 인증-기반 자동복구 대상으로 남는다. "복구 가능한 유실"과 "명시적 삭제"를
+     * 구분하려면 DELETE 시 tombstone 마커를 남기는 별도 설계가 필요하며, 이는
+     * 계약 R1~R9 범위 밖이라 구현하지 않았다 (보고서 참고).
+     * 이 테스트는 그 알려진 gap을 명시적으로 문서화한다 — auth가 유효한 한
+     * 보안 홀은 아니지만, 계약의 리터럴 문구와는 다르다.
+     */
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-03-26" });
+
+    const delReq = makeDeleteReq({ "mcp-session-id": sessionId });
+    const delRes = makeRes();
+    await handleMcpDelete(delReq, delRes);
+    assert.strictEqual(delRes.statusCode, 200);
+
+    assert.strictEqual(streamableSessions.has(sessionId), false, "DELETE 후 메모리에서 제거되어야 한다");
+    assert.strictEqual(await fakeRedisModule.getSession(sessionId), null, "DELETE 후 Redis에서도 제거되어야 한다");
+
+    const { res } = await callToolsList(sessionId, { "mcp-protocol-version": "2025-03-26" });
+    assert.strictEqual(res.statusCode, 200, "현재 구현에서는 auth 유효 시 자동복구된다 (알려진 gap — 위 주석 참고)");
   });
 });

--- a/tests/unit/mcp-protocol-reanchor-integration.test.js
+++ b/tests/unit/mcp-protocol-reanchor-integration.test.js
@@ -1,0 +1,354 @@
+/**
+ * MCP protocol-version 자가치유 — 실제 핸들러 통합 테스트
+ *
+ * 작성자: codex (계약 위임 구현)
+ * 작성일: 2026-07-26
+ *
+ * 배경 (findings/anchormind-protocol-mismatch-contract-20260725.md):
+ *   서버 재기동 시 in-memory streamableSessions Map은 비워지지만 Redis 세션은
+ *   preserveRedis:true로 살아남는다. 이때 Redis 복원 경로(lib/sessions.js
+ *   validateStreamableSession)는 `...redisSession` 스프레드로 전 필드를 복원하므로
+ *   stale negotiatedVersion이 되살아난다. 그 값이 클라이언트의
+ *   MCP-Protocol-Version 헤더와 다르면 구 코드는 이후 모든 요청을 HTTP 400
+ *   -32000 "Protocol version mismatch"로 영구 거부했다 — 재initialize 전까지
+ *   회복 불가능한 장애였다.
+ *
+ * 이 파일은 tests/unit/mcp-protocol-version.test.js / mcp-404-session.test.js의
+ * "분기 로직을 복사한 순수 함수" 검증의 공백을 메운다: 실제 initialize →
+ * (fake) Redis 저장 → in-memory Map 초기화(재기동 시뮬레이션) → 실제 Redis 복원 →
+ * 실제 protocol validation까지 mcp-handler.js / sessions.js의 진짜 코드로 수행한다.
+ *
+ * 모킹 대상은 lib/redis.js 단 하나뿐이다 (실제 ioredis 연결 없이 세션 저장/조회/
+ * 삭제를 인메모리로 재현). saveSession/getSession/deleteSession/bindTokenToSession/
+ * getSessionIdByToken은 sessions.js·mcp-handler.js가 상수 redisClient를 직접
+ * 참조하므로 `__setRedisClientForTest`로는 가로챌 수 없다 — 모듈 자체를 mock한다.
+ * 인증은 master key(MEMENTO_ACCESS_KEY) 경로를 사용해 DB(admin/ApiKeyStore.js,
+ * getGroupKeyIds)와 rate-limit 캐시(getRateLimitUsageCached)가 전혀 호출되지
+ * 않도록 한다(keyId=null이면 두 경로 모두 가드로 스킵됨) — 그 외 로직은 전부 실물이다.
+ */
+
+import { describe, it, mock, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+
+/**
+ * config.js는 최초 import 시점의 process.env를 그대로 캡처하므로, 이 값들은
+ * 반드시 아래의 동적 import보다 먼저 설정되어야 한다 (정적 import는 호이스팅되어
+ * 파일 최상단에서 먼저 평가되므로, config.js를 정적 import하는 대신 이후 모든
+ * 관련 모듈을 동적 import로 불러온다).
+ */
+process.env.MEMENTO_ACCESS_KEY      = "reanchor-it-master-key-20260726";
+process.env.REDIS_ENABLED           = "true";
+process.env.MEMENTO_METRICS_DEFAULT = "off";
+
+/** ------------------------------------------------------------------
+ *  인메모리 fake Redis — lib/redis.js 전체를 대체한다.
+ *  세션 관련 5개 함수(getSession/saveSession/deleteSession/bindTokenToSession/
+ *  getSessionIdByToken)만 실제와 동등하게 동작하고, 나머지는 mcp-handler.js의
+ *  import 그래프(jsonrpc.js → tools/index.js → 각 도구 구현)가 링크 단계에서
+ *  요구하는 이름을 전부 채우기 위한 무해한 스텁이다.
+ * ------------------------------------------------------------------ */
+const _store = new Map();
+
+function _rawGet(key) {
+  const entry = _store.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    _store.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+function _rawSet(key, value, ttlSeconds) {
+  _store.set(key, { value, expiresAt: Date.now() + Math.max(ttlSeconds, 1) * 1000 });
+}
+
+const fakeRedisClient = {
+  status: "fake",
+  get: async () => null, set: async () => "OK", setex: async () => "OK", del: async () => 0,
+  lpush: async () => 0, rpush: async () => 0, rpop: async () => null, lpop: async () => null,
+  rpoplpush: async () => null, lrem: async () => 0,
+  keys: async () => [], scan: async () => ["0", []],
+  llen: async () => 0, expire: async () => 1, ping: async () => "PONG",
+  hset: async () => 1, hgetall: async () => ({}),
+  quit: async () => {}, disconnect: () => {},
+  on: () => {}, once: () => {}, removeListener: () => {}
+};
+
+const fakeRedisModule = {
+  redisClient: fakeRedisClient,
+  async checkRedisHealth() { return { healthy: true, message: "fake" }; },
+  getSessionKey: (id) => `session:${id}`,
+  getOAuthCodeKey: (c) => `oauth:code:${c}`,
+  getOAuthTokenKey: (t) => `oauth:token:${t}`,
+  getDocCacheKey: (p) => `cache:doc:${p}`,
+  getDbCacheKey: () => "cache:db:fake",
+  getTokenSessionKey: (t) => `token:session:${t}`,
+
+  /** 세션 저장/조회/삭제 — 이 테스트가 실제로 의존하는 부분 */
+  async saveSession(sessionId, sessionData, ttlSeconds) {
+    _rawSet(`session:${sessionId}`, JSON.stringify(sessionData), ttlSeconds);
+    return true;
+  },
+  async getSession(sessionId) {
+    const raw = _rawGet(`session:${sessionId}`);
+    return raw ? JSON.parse(raw) : null;
+  },
+  async deleteSession(sessionId) {
+    _store.delete(`session:${sessionId}`);
+    return true;
+  },
+  async extendSessionTTL() { return true; },
+
+  /** 토큰-세션 역인덱스 */
+  async bindTokenToSession(tokenKey, sessionId, ttlSeconds) {
+    _rawSet(`token:session:${tokenKey}`, sessionId, ttlSeconds);
+    return true;
+  },
+  async getSessionIdByToken(tokenKey) {
+    return _rawGet(`token:session:${tokenKey}`);
+  },
+  async unbindToken(tokenKey) {
+    _store.delete(`token:session:${tokenKey}`);
+    return true;
+  },
+
+  /** OAuth / 캐싱 / 큐 — 이 테스트 경로에서는 호출되지 않는 무해한 스텁 */
+  async saveOAuthCode() { return true; },
+  async consumeOAuthCode() { return null; },
+  async saveOAuthToken() { return true; },
+  async getOAuthToken() { return null; },
+  async deleteOAuthToken() { return true; },
+  async extendOAuthToken() { return true; },
+  async cacheDocument() { return true; },
+  async getCachedDocument() { return null; },
+  async invalidateDocumentCache() { return true; },
+  async cacheDbQuery() { return true; },
+  async getCachedDbQuery() { return null; },
+  async invalidateCacheByPattern() { return 0; },
+  async pushToQueue() { return true; },
+  async pushToQueuePriority() { return true; },
+  async popFromQueue() { return null; },
+  __setRedisClientForTest() {},
+  async popFromQueueReliable() { return null; },
+  async ackQueueItem() { return true; },
+  async requeueProcessing() { return 0; },
+  async pushToQueueDead() { return true; },
+  async getQueueLength() { return 0; },
+  async closeRedis() {},
+  async connectRedis() {},
+  async disconnectRedis() {},
+  async setBatchJobStatus() { return true; },
+  async getBatchJobStatus() { return null; }
+};
+
+mock.module("../../lib/redis.js", {
+  namedExports: fakeRedisModule,
+  defaultExport: fakeRedisClient
+});
+
+const { handleMcpPost }                         = await import("../../lib/handlers/mcp-handler.js");
+const { streamableSessions }                    = await import("../../lib/sessions.js");
+const { protocolVersionReanchoredTotal }        = await import("../../lib/metrics.js");
+
+const MASTER_KEY   = process.env.MEMENTO_ACCESS_KEY;
+const rateLimiter  = { allow: () => true };
+const SUPPORTED    = ["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"];
+
+/** ------------------------------------------------------------------
+ *  req/res 페이크 — handleMcpPost가 요구하는 최소 인터페이스
+ * ------------------------------------------------------------------ */
+
+function makeReq(bodyObj, headers = {}) {
+  const req = new Readable({ read() {} });
+  req.push(Buffer.from(JSON.stringify(bodyObj)));
+  req.push(null);
+  req.headers = { host: "localhost:57332", authorization: `Bearer ${MASTER_KEY}`, ...headers };
+  req.method  = "POST";
+  req.url     = "/mcp";
+  req.socket  = { remoteAddress: "127.0.0.1", encrypted: false };
+  return req;
+}
+
+function makeRes() {
+  const headers = {};
+  const res = {
+    statusCode: 200,
+    body      : undefined,
+    setHeader(name, value) { headers[name.toLowerCase()] = value; },
+    getHeader(name) { return headers[name.toLowerCase()]; },
+    end(data) { res.body = data; },
+    writeHead(code, hdrs) {
+      res.statusCode = code;
+      if (hdrs) for (const [k, v] of Object.entries(hdrs)) headers[k.toLowerCase()] = v;
+    },
+    _headers: headers
+  };
+  return res;
+}
+
+function parseBody(res) {
+  if (res.body === undefined || res.body === null) return null;
+  try { return JSON.parse(res.body); } catch { return res.body; }
+}
+
+let _seq = 0;
+
+async function initializeSession({ protocolVersion = "2025-03-26", headers = {} } = {}) {
+  const req = makeReq(
+    { jsonrpc: "2.0", id: ++_seq, method: "initialize", params: { protocolVersion, capabilities: {}, clientInfo: { name: "it-client", version: "1.0" } } },
+    headers
+  );
+  const res = makeRes();
+  await handleMcpPost(req, res, process.hrtime.bigint(), rateLimiter);
+  assert.strictEqual(res.statusCode, 200, `initialize 실패: ${res.body}`);
+  const sessionId = res._headers["mcp-session-id"];
+  assert.ok(sessionId, "MCP-Session-Id 헤더가 있어야 한다");
+  return { sessionId, body: parseBody(res) };
+}
+
+async function callToolsList(sessionId, headers = {}) {
+  const req = makeReq({ jsonrpc: "2.0", id: ++_seq, method: "tools/list", params: {} }, { "mcp-session-id": sessionId, ...headers });
+  const res = makeRes();
+  await handleMcpPost(req, res, process.hrtime.bigint(), rateLimiter);
+  return { res, body: parseBody(res) };
+}
+
+/* ==================================================================== */
+/*  테스트                                                                */
+/* ==================================================================== */
+
+describe("MCP protocol-version 자가치유 — 실제 핸들러 통합 테스트", () => {
+
+  beforeEach(() => {
+    /**
+     * 각 테스트를 완전히 격리한다. master key 인증은 항상 동일한 토큰 문자열이므로
+     * deriveTokenKey의 토큰-세션 재사용 기능(claude.ai 커넥터 대응, _createInitializeSession
+     * 참고)이 그대로 두면 테스트마다 같은 세션을 재사용해버려 "매 initialize는 새
+     * 세션"이라는 이 테스트 스위트의 전제가 깨진다. in-memory Map과 fake Redis를
+     * 모두 비워 매 테스트가 독립적인 세션에서 출발하도록 한다.
+     */
+    streamableSessions.clear();
+    _store.clear();
+  });
+
+  it("I3 (핵심 회귀): negotiatedVersion=2025-03-26 세션에 헤더 2025-06-18로 tools/call → 200 (구 400 mismatch 폐기, R1)", async () => {
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-03-26" });
+
+    const { res, body } = await callToolsList(sessionId, { "mcp-protocol-version": "2025-06-18" });
+
+    assert.strictEqual(res.statusCode, 200, `mismatch reanchor 실패: ${JSON.stringify(body)}`);
+    assert.ok(Array.isArray(body?.result?.tools), "tools/list 결과가 정상 반환되어야 한다");
+
+    const session = streamableSessions.get(sessionId);
+    assert.strictEqual(session.negotiatedVersion, "2025-06-18", "세션이 헤더 값으로 재앵커링되어야 한다");
+  });
+
+  it("I2: 재기동 시뮬레이션(streamableSessions.clear 대응 — 개별 delete) 후 동일 sessionId 호출 → 200 (Redis 보존)", async () => {
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-06-18" });
+
+    /** 재기동 시뮬레이션: in-memory Map만 비운다. Redis(fake)는 그대로 보존된다. */
+    streamableSessions.delete(sessionId);
+
+    const { res, body } = await callToolsList(sessionId, { "mcp-protocol-version": "2025-06-18" });
+    assert.strictEqual(res.statusCode, 200, `재기동 후 세션 복원 실패: ${JSON.stringify(body)}`);
+  });
+
+  it("I13: Redis에 stale negotiatedVersion(null)이 저장돼 있어도 복원 시 요청 헤더로 즉시 재앵커링된다 (R2)", async () => {
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-03-26" });
+
+    /** 구버전 버그 재현: Redis에 저장된 negotiatedVersion을 인위적으로 null로 되돌린다 */
+    const raw = await fakeRedisModule.getSession(sessionId);
+    raw.negotiatedVersion = null;
+    await fakeRedisModule.saveSession(sessionId, raw, 3600);
+
+    streamableSessions.delete(sessionId); // 재기동 시뮬레이션
+
+    const { res } = await callToolsList(sessionId, { "mcp-protocol-version": "2025-11-25" });
+    assert.strictEqual(res.statusCode, 200);
+
+    const restored = streamableSessions.get(sessionId);
+    assert.strictEqual(restored.negotiatedVersion, "2025-11-25", "Redis 복원 직후 헤더 값으로 재앵커링되어야 한다 (R2)");
+
+    const persisted = await fakeRedisModule.getSession(sessionId);
+    assert.strictEqual(persisted.negotiatedVersion, "2025-11-25", "재앵커링된 값이 Redis에도 즉시 반영되어야 한다");
+  });
+
+  it("검증 순서 결함 회귀: 재기동 복원 요청의 미지원 헤더는 400으로 거부되고, 거부 전에 세션/Redis/메트릭에 새겨지지 않는다", async () => {
+    /**
+     * 독립 재검토에서 확정된 결함: _resolveExistingSession이 검증 전 raw 헤더값
+     * (fallbackProtoValue)을 validateStreamableSession/createStreamableSessionWithId에
+     * 넘겼다. 실제 지원 여부 검사(_validateProtocolVersion)는 호출 순서상 그 뒤에
+     * 실행되므로, 미지원 값이 거부되기 *전에* 이미 세션 negotiatedVersion·Redis·
+     * Prometheus reanchor 메트릭 label에 새겨졌다(무한 카디널리티 위험 포함).
+     * 이 테스트는 세 가지 부작용이 전혀 발생하지 않음을 증명한다.
+     */
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-03-26" });
+
+    /** 재기동 시뮬레이션: in-memory Map만 비운다 — fake Redis는 "2025-03-26"을 보존 */
+    streamableSessions.delete(sessionId);
+
+    const before = await protocolVersionReanchoredTotal.get();
+    const totalBefore = before.values.reduce((sum, v) => sum + v.value, 0);
+
+    for (const badHeader of ["2099-01-01", "not-a-real-version"]) {
+      const { res, body } = await callToolsList(sessionId, { "mcp-protocol-version": badHeader });
+
+      // (a) 400으로 거부되어야 한다 (기존 _validateProtocolVersion 경로, 변경 없음)
+      assert.strictEqual(res.statusCode, 400, `${badHeader} → 400이어야 한다: ${JSON.stringify(body)}`);
+      assert.ok(body.error.message.includes("Unsupported protocol version"), body.error.message);
+
+      // (b) 세션 negotiatedVersion이 미지원 값으로 오염되지 않아야 한다
+      const session = streamableSessions.get(sessionId);
+      assert.ok(session, "거부되더라도 세션 자체는 복원되어 있어야 한다");
+      assert.notStrictEqual(session.negotiatedVersion, badHeader, "미지원 헤더 값이 세션에 새겨지면 안 된다");
+      assert.strictEqual(session.negotiatedVersion, "2025-03-26", "negotiatedVersion은 원래 값을 유지해야 한다");
+
+      // (b') fake Redis에도 미지원 값이 영속되면 안 된다
+      const persisted = await fakeRedisModule.getSession(sessionId);
+      assert.notStrictEqual(persisted?.negotiatedVersion, badHeader, "미지원 헤더 값이 Redis에 영속되면 안 된다");
+      assert.strictEqual(persisted?.negotiatedVersion, "2025-03-26", "Redis의 negotiatedVersion도 원래 값을 유지해야 한다");
+
+      // 다음 반복을 위해 다시 재기동 상태로 되돌린다 (in-memory만 비움)
+      streamableSessions.delete(sessionId);
+    }
+
+    // (c) reanchor 메트릭이 증가하지 않아야 한다 — 미지원 값으로 인한 label 카디널리티 오염 금지
+    const after = await protocolVersionReanchoredTotal.get();
+    const totalAfter = after.values.reduce((sum, v) => sum + v.value, 0);
+    assert.strictEqual(totalAfter, totalBefore, "미지원 헤더는 reanchor 메트릭을 증가시키면 안 된다");
+    assert.ok(
+      !after.values.some(v => v.labels.to === "2099-01-01" || v.labels.to === "not-a-real-version"),
+      "미지원 헤더 값이 reanchor 메트릭의 'to' label로 기록되면 안 된다 (카디널리티 오염 금지)"
+    );
+  });
+
+  it("R3: initialize 직후 negotiatedVersion이 Redis에 즉시 영속된다 (다음 요청까지 지연되지 않음)", async () => {
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-11-25" });
+    const persisted = await fakeRedisModule.getSession(sessionId);
+    assert.strictEqual(persisted.negotiatedVersion, "2025-11-25", "initialize 응답 직후 Redis에 즉시 저장되어야 한다");
+  });
+
+  it("A1 (회귀 가드): SUPPORTED_PROTOCOL_VERSIONS의 어떤 값도 400을 유발하지 않는다", async () => {
+    const { sessionId } = await initializeSession({ protocolVersion: "2025-03-26" });
+    for (const ver of SUPPORTED) {
+      const { res, body } = await callToolsList(sessionId, { "mcp-protocol-version": ver });
+      assert.notStrictEqual(res.statusCode, 400, `${ver} → 400 발생: ${JSON.stringify(body)}`);
+    }
+  });
+
+  it("C1: 세션 부재(Session not found) + 인증 유효 → 200 자동복구 (클라이언트에는 투명)", async () => {
+    const req = makeReq(
+      { jsonrpc: "2.0", id: ++_seq, method: "tools/list", params: {} },
+      { "mcp-session-id": "ghost-but-authenticated-session", "mcp-protocol-version": "2025-06-18" }
+    );
+    const res = makeRes();
+    await handleMcpPost(req, res, process.hrtime.bigint(), rateLimiter);
+
+    assert.strictEqual(res.statusCode, 200, `자동복구 실패: ${res.body}`);
+    const session = streamableSessions.get("ghost-but-authenticated-session");
+    assert.ok(session, "세션이 생성되어야 한다");
+    assert.strictEqual(session.negotiatedVersion, "2025-06-18", "자동복구 세션도 헤더 값으로 즉시 채워져야 한다 (R2)");
+  });
+});

--- a/tests/unit/mcp-protocol-version.test.js
+++ b/tests/unit/mcp-protocol-version.test.js
@@ -12,7 +12,7 @@
  *  1. initialize 응답 후 negotiatedVersion이 세션에 저장됨
  *  2. 헤더 없음 → 2025-03-26 fallback (통과)
  *  3. 헤더=세션 version 일치 → 통과
- *  4. 헤더=미지원 version → 400 ("Unsupported protocol version")
+ *  4. 헤더=미지원 version → 400, "Unsupported protocol version" 부분문자열 포함
  *  5. 헤더=지원 version이지만 세션 version과 다름 → 200 + 재앵커링 (구 400 계약 폐기, R1)
  *  6. initialize 요청은 헤더 검증 생략
  *
@@ -36,8 +36,7 @@ const FALLBACK_VERSION = "2025-03-26";
 
 /**
  * handleMcpPost의 Protocol-Version 검증 분기 로직 순수 함수 재현
- * (mcp-handler.js `_validateProtocolVersion`, 계약 R1 반영. 메시지 확장/data
- * 봉투는 R4 — 별도 브랜치 agent/mcp-error-recovery-contract 범위).
+ * (mcp-handler.js `_validateProtocolVersion`, 계약 R1/R4 반영).
  *
  * @param {object} params
  * @param {string}           params.method            - JSON-RPC 메서드
@@ -56,7 +55,9 @@ function checkProtocolVersion({ method, protoHeader, sessionNegotiated }) {
   const effectiveVersion = protoHeader || FALLBACK_VERSION;
 
   if (!SUPPORTED_PROTOCOL_VERSIONS.includes(effectiveVersion)) {
-    return { status: 400, message: "Unsupported protocol version", effectiveVersion, reanchored: false, negotiatedVersionAfter: sessionNegotiated ?? null };
+    const message = `Bad Request: Unsupported protocol version: ${effectiveVersion} ` +
+      `(supported versions: ${SUPPORTED_PROTOCOL_VERSIONS.join(", ")})`;
+    return { status: 400, message, effectiveVersion, reanchored: false, negotiatedVersionAfter: sessionNegotiated ?? null };
   }
 
   if (!protoHeader) {
@@ -89,7 +90,7 @@ function simulateInitializeVersionStore(responseProtocolVersion) {
 /*  테스트 케이스                                                       */
 /* ================================================================== */
 
-describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3 + 계약 R1)", () => {
+describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3 + 계약 R1/R4)", () => {
 
   it("TC1: initialize 응답 후 negotiatedVersion이 세션에 저장됨", () => {
     const session = simulateInitializeVersionStore("2025-06-18");
@@ -123,14 +124,18 @@ describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3 + 계약 R1)", () => {
     assert.strictEqual(result.reanchored, false);
   });
 
-  it("TC4: 헤더=미지원 version → 400", () => {
+  it("TC4: 헤더=미지원 version → 400, 'Unsupported protocol version' 부분문자열 포함", () => {
     const result = checkProtocolVersion({
       method           : "tools/call",
       protoHeader      : "2099-01-01",
       sessionNegotiated: "2025-06-18"
     });
     assert.strictEqual(result.status, 400);
-    assert.strictEqual(result.message, "Unsupported protocol version");
+    assert.ok(
+      result.message.includes("Unsupported protocol version"),
+      `A2 회귀 가드: 메시지에 'Unsupported protocol version' 부분문자열이 있어야 한다 (실제: ${result.message})`
+    );
+    assert.ok(result.message.includes("2099-01-01"), "받은 버전 값이 메시지에 포함되어야 한다");
   });
 
   it("TC5: 헤더=지원 version이지만 세션 version과 다름 → 200 + 재앵커링 (계약 R1, 구 400 폐기)", () => {

--- a/tests/unit/mcp-protocol-version.test.js
+++ b/tests/unit/mcp-protocol-version.test.js
@@ -3,16 +3,23 @@
  *
  * 작성자: 최진호
  * 작성일: 2026-04-17
+ * 수정일: 2026-07-26 — 계약 findings/anchormind-protocol-mismatch-contract-20260725.md
+ *         반영. negotiatedVersion 불일치를 거부(400)하던 옛 계약을 폐기하고,
+ *         헤더 값으로 재앵커링하는 자가치유(C3)로 교체했다 (R1).
+ *         구 TC5는 폐기된 계약(mismatch→400)을 고정하고 있어 반드시 교체 대상이었다.
  *
  * 검증 대상 (MCP 2025-06-18 스펙 준수):
  *  1. initialize 응답 후 negotiatedVersion이 세션에 저장됨
  *  2. 헤더 없음 → 2025-03-26 fallback (통과)
  *  3. 헤더=세션 version 일치 → 통과
- *  4. 헤더=미지원 version → 400
- *  5. 헤더=지원 version이지만 세션 version과 다름 → 400
+ *  4. 헤더=미지원 version → 400 ("Unsupported protocol version")
+ *  5. 헤더=지원 version이지만 세션 version과 다름 → 200 + 재앵커링 (구 400 계약 폐기, R1)
  *  6. initialize 요청은 헤더 검증 생략
  *
- * 인프라 의존성 없이 순수 함수로 분기 로직을 재현하여 검증한다.
+ * 인프라 의존성 없이 순수 함수로 분기 로직을 재현하여 검증한다. 실제 핸들러
+ * (mcp-handler.js)·세션(sessions.js)을 호출하는 진짜 통합 테스트는
+ * tests/unit/mcp-protocol-reanchor-integration.test.js 참고 — 그 파일이
+ * red(수정 전 400) → green(수정 후 200) 전환의 실측 증거를 담당한다.
  */
 
 import { describe, it } from "node:test";
@@ -28,30 +35,43 @@ const SUPPORTED_PROTOCOL_VERSIONS = [
 const FALLBACK_VERSION = "2025-03-26";
 
 /**
- * handleMcpPost의 Protocol-Version 검증 분기 로직 순수 함수 재현.
+ * handleMcpPost의 Protocol-Version 검증 분기 로직 순수 함수 재현
+ * (mcp-handler.js `_validateProtocolVersion`, 계약 R1 반영. 메시지 확장/data
+ * 봉투는 R4 — 별도 브랜치 agent/mcp-error-recovery-contract 범위).
  *
  * @param {object} params
- * @param {string}          params.method              - JSON-RPC 메서드
+ * @param {string}           params.method            - JSON-RPC 메서드
  * @param {string|undefined} params.protoHeader        - req.headers["mcp-protocol-version"] 값
- * @param {string|null}     params.sessionNegotiated   - session.negotiatedVersion 값
- * @returns {{ status: number, message: string|null, effectiveVersion: string|null }}
+ * @param {string|null|undefined} params.sessionNegotiated
+ *   - 세션의 negotiatedVersion 값. `undefined`는 "세션 자체가 없음"(재앵커링 스킵),
+ *     `null`은 "세션은 있으나 아직 협상되지 않음"(재앵커링 대상)을 의미한다.
+ * @returns {{ status: number, message: string|null, effectiveVersion: string|null,
+ *             reanchored: boolean, negotiatedVersionAfter: string|null }}
  */
 function checkProtocolVersion({ method, protoHeader, sessionNegotiated }) {
   if (method === "initialize") {
-    return { status: 200, message: null, effectiveVersion: null };
+    return { status: 200, message: null, effectiveVersion: null, reanchored: false, negotiatedVersionAfter: sessionNegotiated ?? null };
   }
 
   const effectiveVersion = protoHeader || FALLBACK_VERSION;
 
   if (!SUPPORTED_PROTOCOL_VERSIONS.includes(effectiveVersion)) {
-    return { status: 400, message: "Unsupported protocol version", effectiveVersion };
+    return { status: 400, message: "Unsupported protocol version", effectiveVersion, reanchored: false, negotiatedVersionAfter: sessionNegotiated ?? null };
   }
 
-  if (protoHeader && sessionNegotiated && sessionNegotiated !== protoHeader) {
-    return { status: 400, message: "Protocol version mismatch", effectiveVersion };
+  if (!protoHeader) {
+    return { status: 200, message: null, effectiveVersion, reanchored: false, negotiatedVersionAfter: sessionNegotiated ?? null };
   }
 
-  return { status: 200, message: null, effectiveVersion };
+  /**
+   * R1 자가치유: 세션이 존재하고(sessionNegotiated !== undefined) negotiatedVersion이
+   * 헤더와 다르면(null이었던 경우 포함) 거부하지 않고 헤더 값으로 재앵커링한다.
+   */
+  if (sessionNegotiated !== undefined && sessionNegotiated !== protoHeader) {
+    return { status: 200, message: null, effectiveVersion, reanchored: true, negotiatedVersionAfter: protoHeader };
+  }
+
+  return { status: 200, message: null, effectiveVersion, reanchored: false, negotiatedVersionAfter: sessionNegotiated ?? protoHeader };
 }
 
 /**
@@ -69,7 +89,7 @@ function simulateInitializeVersionStore(responseProtocolVersion) {
 /*  테스트 케이스                                                       */
 /* ================================================================== */
 
-describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3)", () => {
+describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3 + 계약 R1)", () => {
 
   it("TC1: initialize 응답 후 negotiatedVersion이 세션에 저장됨", () => {
     const session = simulateInitializeVersionStore("2025-06-18");
@@ -89,9 +109,10 @@ describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3)", () => {
     });
     assert.strictEqual(result.status, 200);
     assert.strictEqual(result.effectiveVersion, FALLBACK_VERSION);
+    assert.strictEqual(result.reanchored, false, "헤더 없는 fallback 경로는 재앵커링하지 않는다");
   });
 
-  it("TC3: 헤더=세션 version 일치 → 통과", () => {
+  it("TC3: 헤더=세션 version 일치 → 통과 (재앵커링 없음)", () => {
     const result = checkProtocolVersion({
       method           : "tools/call",
       protoHeader      : "2025-06-18",
@@ -99,6 +120,7 @@ describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3)", () => {
     });
     assert.strictEqual(result.status, 200);
     assert.strictEqual(result.message, null);
+    assert.strictEqual(result.reanchored, false);
   });
 
   it("TC4: 헤더=미지원 version → 400", () => {
@@ -111,14 +133,16 @@ describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3)", () => {
     assert.strictEqual(result.message, "Unsupported protocol version");
   });
 
-  it("TC5: 헤더=지원 version이지만 세션 version과 다름 → 400", () => {
+  it("TC5: 헤더=지원 version이지만 세션 version과 다름 → 200 + 재앵커링 (계약 R1, 구 400 폐기)", () => {
     const result = checkProtocolVersion({
       method           : "tools/call",
       protoHeader      : "2025-03-26",
       sessionNegotiated: "2025-06-18"
     });
-    assert.strictEqual(result.status, 400);
-    assert.strictEqual(result.message, "Protocol version mismatch");
+    assert.strictEqual(result.status, 200, "구 계약(400 mismatch)은 폐기되었다 — 거부하지 않는다");
+    assert.strictEqual(result.message, null);
+    assert.strictEqual(result.reanchored, true, "세션 negotiatedVersion을 헤더 값으로 재앵커링해야 한다");
+    assert.strictEqual(result.negotiatedVersionAfter, "2025-03-26", "재앵커링 이후 값은 헤더 값이어야 한다");
   });
 
   it("TC6: initialize 요청은 헤더 검증 생략 (항상 통과)", () => {
@@ -130,13 +154,15 @@ describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3)", () => {
     assert.strictEqual(result.status, 200, "initialize는 헤더 검증 대상에서 제외");
   });
 
-  it("TC7: 헤더=지원 version + 세션 negotiatedVersion null → 통과", () => {
+  it("TC7: 헤더=지원 version + 세션 negotiatedVersion null → 통과 + 재앵커링 (null 공백 해소, R1/R2)", () => {
     const result = checkProtocolVersion({
       method           : "tools/list",
       protoHeader      : "2025-06-18",
       sessionNegotiated: null   // initialize 직후 아직 저장 안 된 경우
     });
     assert.strictEqual(result.status, 200);
+    assert.strictEqual(result.reanchored, true, "null negotiatedVersion도 헤더 값으로 채워야 한다");
+    assert.strictEqual(result.negotiatedVersionAfter, "2025-06-18");
   });
 
   it("TC8: 모든 SUPPORTED_PROTOCOL_VERSIONS가 개별적으로 통과", () => {
@@ -147,6 +173,33 @@ describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3)", () => {
         sessionNegotiated: ver
       });
       assert.strictEqual(result.status, 200, `${ver} should pass`);
+    }
+  });
+
+  /* ================================================================ */
+  /*  회귀 가드 (계약 §4 A1/A2)                                          */
+  /* ================================================================ */
+
+  it("A1: SUPPORTED_PROTOCOL_VERSIONS의 어떤 값도 400을 유발하지 않는다 (세션 미존재 포함)", () => {
+    for (const ver of SUPPORTED_PROTOCOL_VERSIONS) {
+      const withSession = checkProtocolVersion({ method: "tools/call", protoHeader: ver, sessionNegotiated: "2024-11-05" });
+      const noSession    = checkProtocolVersion({ method: "tools/call", protoHeader: ver, sessionNegotiated: undefined });
+      assert.notStrictEqual(withSession.status, 400, `${ver} + 세션 있음 → 400 금지`);
+      assert.notStrictEqual(noSession.status,    400, `${ver} + 세션 없음 → 400 금지`);
+    }
+  });
+
+  it("A2: 400 응답의 message는 항상 'Unsupported protocol version' 부분문자열을 포함한다", () => {
+    const unsupportedSamples = ["2099-01-01", "1999-01-01", "not-a-version", ""];
+    for (const bad of unsupportedSamples) {
+      const result = checkProtocolVersion({ method: "tools/call", protoHeader: bad, sessionNegotiated: null });
+      if (bad === "") {
+        /** 빈 문자열 헤더는 protoHeader가 falsy이므로 fallback(2025-03-26, 지원됨)으로 통과 */
+        assert.strictEqual(result.status, 200);
+        continue;
+      }
+      assert.strictEqual(result.status, 400, `${bad}는 미지원이므로 400이어야 한다`);
+      assert.ok(result.message.includes("Unsupported protocol version"), `메시지: ${result.message}`);
     }
   });
 });


### PR DESCRIPTION
> **제안 구현입니다(draft).** 머지를 요청드리는 것이 아니라, #27에서 제안드린
> 계약이 코드로는 어떤 모양이 되는지 보여드리기 위한 참고 구현입니다.
> 스키마·열거값·상태 코드는 모두 논의 대상이며, 방향에 동의하지 않으시면 닫으셔도 됩니다.

## 관련

- 제안·논의: #27
- **선행 PR: #26 위에 쌓여 있습니다.** 이 PR의 diff에는 #26의 커밋이 함께 보입니다.
  #26이 머지되면 rebase해서 이 PR에는 제안 부분만 남도록 정리하겠습니다.
- 배경 이슈: #23 (증상 3)

## 이 PR의 범위

#26이 원인(재기동 후 stale `negotiatedVersion`)을 수정하는 버그 수정이라면,
이 PR은 그와 별개인 **오류 응답의 판별 가능성** 문제를 다룹니다.

`[PROPOSAL]`로 시작하는 커밋 2개가 이 PR의 내용입니다.

- `380f77c` — 세션·프로토콜·인증 4xx에 복구 가능 여부 계약 추가
- `e5e6788` — 해당 계약의 테스트

## 변경 내용

### 1. `error.data` 봉투 (R4·R6)

세션·프로토콜·인증 관련 4xx에 `reason` / `recoverable` / `recoveryAction`과
진단 정보를 싣습니다. `jsonRpcError`가 이미 4번째 인자로 `data`를 받으므로 시그니처
변경은 없고, `error.data`는 JSON-RPC 선택 필드라 이를 읽지 않는 클라이언트에는
영향이 없습니다.

지원하지 않는 프로토콜 버전에 대한 400 message도 공식 SDK와 같은 형태
(`Bad Request: Unsupported protocol version: <v> (supported versions: ...)`)로
확장했습니다. `Unsupported protocol version` 부분문자열은 기존 클라이언트의
문자열 매칭을 깨지 않도록 그대로 유지했습니다.

### 2. 상태 코드·오류 코드 정정 (R5)

- 인증이 무효한 경우 404 → **401 + `WWW-Authenticate`** (Authorization 스펙 MUST)
- 세션 부재/종료 시 `-32000` → **`-32001`** (공식 TS SDK 관행과 정렬)

이에 맞춰 `_resolveExistingSession`에서 `"Session expired"`(TTL이 지난, 기록이
남아 있는 세션)를 자동복구 대상에서 분리해 종료된 세션으로 취급합니다.

## 알려진 한계

명시적 `DELETE` 후 즉시 재사용하는 경우는 기록이 완전히 삭제되어
`"Session not found"`로 잡히므로, 인증이 유효하면 **여전히 자동복구됩니다.**
이를 닫으려면 termination tombstone이 필요하고 `rotateSession`·heartbeat close·
`cleanupExpiredSessions`의 의미까지 영향을 받아, 임의로 결정하지 않고 남겨 두었습니다.
이 한계를 명시하는 테스트를 포함했습니다.

## 논의를 부탁드리는 지점

#27에 정리해 두었습니다. 요약하면 열거값의 이름과 범위, `data` 봉투를 적용할 오류의
범위, `sessionId`를 응답에 싣는 것의 적절성, 그리고 상태 코드 변경을 지금 할지
다음 메이저로 미룰지입니다.

## 테스트

`mcp-protocol-version.test.js`, `mcp-404-session.test.js`의 해당 케이스를 새 동작에
맞게 갱신했고, 통합 테스트에 401·`-32001`·`data` 봉투 검증과 위 한계를 명시하는
케이스를 추가했습니다. 전체 통과를 확인했습니다.
