### PR TITLE
recall keywords 폴백 시맨틱 보조 및 응답 진단 정보 보강

### DIFF
--- a/config/memory.js
+++ b/config/memory.js
@@ -130,8 +130,11 @@ export const MEMORY_CONFIG = {
   /** 시맨틱 검색 설정. minSimilarity는 SearchParamAdaptor가 적응형으로 조정한다.
    *  0.40: 12쿼리 골드셋 실측에서 상위5 유용건 최대(0.5는 자유 회상 질의 침묵, 0.35는 노이즈가 이득 상쇄). */
   semanticSearch: {
-    minSimilarity: 0.4,
-    limit        : 30
+    minSimilarity  : 0.4,
+    limit          : 30,
+    /** text 없는 keywords-only 쿼리에서 L3 시맨틱 보조 실행 여부.
+     *  L1/L2는 저장 keywords 배열만 보므로 content 매칭은 이 경로가 유일하다. */
+    keywordFallback: process.env.MEMENTO_KEYWORD_SEMANTIC_FALLBACK !== "false"
   },
   /** 파편 GC 정책 */
   gc: {

--- a/lib/handlers/mcp-handler.js
+++ b/lib/handlers/mcp-handler.js
@@ -58,6 +58,17 @@ export function deriveTokenKey(req, msg, authCheck) {
 }
 
 /**
+ * JSON 파싱 실패 응답 message 조립.
+ * V8 SyntaxError의 위치 정보("... at position N")를 보존해
+ * 대용량 배열 요청에서 손상 지점을 특정할 수 있게 한다.
+ * body 원문은 포함하지 않는다.
+ */
+export function buildParseErrorMessage(err) {
+  const detail = err instanceof SyntaxError && err.message ? `: ${err.message}` : "";
+  return `Parse error${detail}`;
+}
+
+/**
  * tools/call arguments에 서버 인증 컨텍스트를 주입한다 — 순수 함수 (테스트 가능)
  *
  * (1) arguments가 falsy해도 빈 객체를 생성하여 _keyId 주입을 보장한다.
@@ -403,7 +414,7 @@ export async function handleMcpPost(req, res, startTime, rateLimiter) {
       await sendJSON(res, 413, jsonRpcError(null, -32000, "Payload too large"), req);
       return;
     }
-    await sendJSON(res, 400, jsonRpcError(null, -32700, "Parse error"), req);
+    await sendJSON(res, 400, jsonRpcError(null, -32700, buildParseErrorMessage(err)), req);
     return;
   }
 

--- a/lib/handlers/mcp-handler.js
+++ b/lib/handlers/mcp-handler.js
@@ -321,7 +321,12 @@ async function _validateProtocolVersion(req, res, msg, sessionId) {
     const session = streamableSessions.get(sessionId);
     if (session?.negotiatedVersion && session.negotiatedVersion !== protoHeader) {
       recordProtocolVersionRejected(protoHeader);
-      await sendJSON(res, 400, jsonRpcError(msg?.id ?? null, -32000, "Protocol version mismatch"), req);
+      await sendJSON(res, 400, jsonRpcError(
+        msg?.id ?? null,
+        -32000,
+        `Protocol version mismatch: session negotiated ${session.negotiatedVersion} but request sent ${protoHeader}. Re-initialize the session.`,
+        { negotiatedVersion: session.negotiatedVersion, receivedVersion: protoHeader, action: "reinitialize" }
+      ), req);
       return { rejected: true };
     }
   }

--- a/lib/memory/processors/MemoryRecaller.js
+++ b/lib/memory/processors/MemoryRecaller.js
@@ -97,6 +97,7 @@ export class MemoryRecaller {
       topic             : params.topic,
       type              : params.type,
       text              : params.text,
+      contextText       : params.contextText || undefined,
       tokenBudget       : params.tokenBudget || 1000,
       minImportance     : params.minImportance,
       includeSuperseded : params.includeSuperseded || false,

--- a/lib/memory/read/FragmentSearch.js
+++ b/lib/memory/read/FragmentSearch.js
@@ -479,7 +479,8 @@ export class FragmentSearch {
    * @returns {Promise<Object[]>}
    */
   async _buildFallbackCombined(sq, l1MissIds, cached, agentId, keyId, timeRange, searchPath, layerLatency) {
-    /** text 없는 경우: 기존 폴백 방식 유지 (keywords/topic/type만 있는 경우) */
+    /** text 없는 경우: L2 폴백에 keywords 합성 L3 시맨틱 보조를 병렬 결합.
+     *  L1/L2는 저장 keywords 배열만 매칭하므로 content 기반 회수는 이 보조 경로가 담당한다. */
     const fallbackTasks = [
       (async () => {
         const start   = Date.now();
@@ -496,7 +497,29 @@ export class FragmentSearch {
         return results;
       })());
     }
-    const [l2Results, temporalResults = []] = await Promise.all(fallbackTasks);
+
+    const kwFallbackOn = (MEMORY_CONFIG.semanticSearch?.keywordFallback ?? true) &&
+                          EMBEDDING_ENABLED &&
+                          Array.isArray(sq.keywords) && sq.keywords.length > 0;
+    const synthText    = kwFallbackOn
+      ? [sq.keywords.join(" "), sq.contextText].filter(Boolean).join(" ")
+      : null;
+    const l3Task       = kwFallbackOn
+      ? (async () => {
+          const start   = Date.now();
+          const scope   = SearchScope.fromQuery(sq);
+          const results = await this._searchL3(
+            { ...sq, text: synthText }, agentId, keyId, timeRange, scope
+          );
+          layerLatency.l3Ms = Date.now() - start;
+          return results;
+        })()
+      : Promise.resolve([]);
+
+    const [[l2Results, temporalResults = []], l3Results] = await Promise.all([
+      Promise.all(fallbackTasks),
+      l3Task
+    ]);
     searchPath.push(`L2:${l2Results.length}`);
     const combined = [];
     if (l2Results.length > 0) {
@@ -508,6 +531,14 @@ export class FragmentSearch {
     if (temporalResults.length > 0) {
       searchPath.push(`Temporal:${temporalResults.length}`);
       combined.push(...temporalResults);
+    }
+    if (l3Results.length > 0) {
+      const seen = new Set(combined.map(f => f.id));
+      const supplement = l3Results.filter(f => !seen.has(f.id));
+      if (supplement.length > 0) {
+        searchPath.push(`L3kw:${supplement.length}`);
+        combined.push(...supplement);
+      }
     }
 
     return combined;

--- a/lib/memory/signals/SearchEventRecorder.js
+++ b/lib/memory/signals/SearchEventRecorder.js
@@ -97,7 +97,8 @@ export function buildSearchEvent(query, result, meta = {}) {
 
   const l1Match = searchPath.match(/L1:(\d+)/);
   const l2Match = searchPath.match(/L2:(\d+)/);
-  const l3Match = searchPath.match(/L3:(\d+)/);
+  /** text 경로는 "L3:N", keywords 폴백 보조 경로는 "L3kw:N" 세그먼트를 남긴다 */
+  const l3Match = searchPath.match(/L3(?:kw)?:(\d+)/);
 
   const l1Count  = l1Match ? parseInt(l1Match[1], 10) : 0;
   const l2Count  = l2Match ? parseInt(l2Match[1], 10) : 0;

--- a/lib/memory/write/BatchRememberProcessor.js
+++ b/lib/memory/write/BatchRememberProcessor.js
@@ -77,6 +77,12 @@ export class BatchRememberProcessor {
    */
   async process(params, onProgress = null) {
     const fragments = params.fragments;
+    if (typeof fragments === "string") {
+      throw new Error(
+        "fragments must be an array of fragment objects; received a JSON-encoded string. " +
+        "Pass the array value itself, not its stringified form"
+      );
+    }
     if (!Array.isArray(fragments) || fragments.length === 0) {
       throw new Error("fragments array is required and must not be empty");
     }

--- a/lib/tools/memory-schemas.js
+++ b/lib/tools/memory-schemas.js
@@ -797,6 +797,13 @@ export const reflectDefinition = {
                        "전달하면 episode 파편으로 저장되어 세션 간 맥락 연속성에 기여한다. " +
                        "생략 시 summary에서 자동 생성."
       },
+      workspace: {
+        type       : "string",
+        description: "생성되는 모든 reflect 파편에 적용할 워크스페이스. " +
+                       "미지정 시 API 키의 default_workspace, 그것도 없으면 전역(NULL)으로 저장된다. " +
+                       "멀티 프로젝트 환경에서 세션 요약이 다른 프로젝트 context에 주입되는 것을 방지하려면 지정을 권장.",
+        examples   : ["memento-mcp", "personal"]
+      },
       agentId: {
         type       : "string",
         description: "에이전트 ID"

--- a/tests/unit/batch-remember-processor.test.js
+++ b/tests/unit/batch-remember-processor.test.js
@@ -145,9 +145,16 @@ describe("BatchRememberProcessor", () => {
     );
   });
 
-  it("빈 배열 거부: fragments가 배열이 아니면 에러", async () => {
+  it("빈 배열 거부: fragments가 문자열이면 문자열화 진단 에러", async () => {
     await assert.rejects(
       () => processor.process({ fragments: "not-array" }),
+      (err) => err.message.includes("JSON-encoded string")
+    );
+  });
+
+  it("빈 배열 거부: fragments가 배열도 문자열도 아니면 에러", async () => {
+    await assert.rejects(
+      () => processor.process({ fragments: 42 }),
       (err) => err.message.includes("must not be empty")
     );
   });

--- a/tests/unit/batch-remember-string-args.test.js
+++ b/tests/unit/batch-remember-string-args.test.js
@@ -1,0 +1,35 @@
+/**
+ * batch_remember fragments 문자열 입력 진단 메시지 검증
+ *
+ * 작성자: 최진호
+ * 작성일: 2026-07-26
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { BatchRememberProcessor } from "../../lib/memory/write/BatchRememberProcessor.js";
+
+describe("BatchRememberProcessor 문자열 fragments 진단", () => {
+  const proc = new BatchRememberProcessor({ store: null, index: null, factory: null });
+
+  it("fragments가 JSON 문자열이면 문자열화 원인을 명시한 오류를 던진다", async () => {
+    await assert.rejects(
+      proc.process({ fragments: '[{"content":"x","type":"fact"}]' }),
+      /JSON-encoded string/
+    );
+  });
+
+  it("fragments 미지정은 기존 메시지를 유지한다", async () => {
+    await assert.rejects(
+      proc.process({}),
+      /fragments array is required and must not be empty/
+    );
+  });
+
+  it("빈 배열은 기존 메시지를 유지한다", async () => {
+    await assert.rejects(
+      proc.process({ fragments: [] }),
+      /fragments array is required and must not be empty/
+    );
+  });
+});

--- a/tests/unit/keyword-fallback-semantic.test.js
+++ b/tests/unit/keyword-fallback-semantic.test.js
@@ -1,0 +1,144 @@
+/**
+ * keywords-only 쿼리 L3 시맨틱 보조 경로 검증
+ *
+ * 작성자: 최진호
+ * 작성일: 2026-07-26
+ *
+ * text 없는 keywords 쿼리에서 L2가 놓친 content 매칭 파편을
+ * L3 시맨틱 보조가 병합하는지 검증한다.
+ */
+
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+
+let semanticCalls = [];
+
+mock.module("../../lib/redis.js", {
+  namedExports: { redisClient: { status: "stub" } }
+});
+
+mock.module("../../lib/logger.js", {
+  namedExports: {
+    logDebug: mock.fn(), logInfo: mock.fn(), logWarn: mock.fn(), logError: mock.fn()
+  }
+});
+
+mock.module("../../lib/tools/embedding.js", {
+  namedExports: {
+    EMBEDDING_ENABLED      : true,
+    computeContentHash     : () => "hash",
+    generateBatchEmbeddings: async () => [],
+    generateEmbedding      : async (text) => {
+      semanticCalls.push({ kind: "embed", text });
+      return new Array(4).fill(0.1);
+    },
+    prepareTextForEmbedding: text => String(text ?? ""),
+    vectorToSql            : vector => `[${vector.join(",")}]`
+  }
+});
+
+mock.module("../../lib/memory/signals/SearchMetrics.js", {
+  namedExports: { getSearchMetrics: async () => ({ record: async () => {} }) }
+});
+
+mock.module("../../lib/memory/signals/SearchParamAdaptor.js", {
+  namedExports: { getSearchParamAdaptor: () => ({ getMinSimilarity: async () => null }) }
+});
+
+mock.module("../../lib/memory/read/SearchSideEffects.js", {
+  namedExports: { commitSearchSideEffects: async () => null }
+});
+
+mock.module("../../lib/memory/read/Reranker.js", {
+  namedExports: { isRerankerAvailable: () => false, rerank: async () => null }
+});
+
+const { FragmentSearch } = await import("../../lib/memory/read/FragmentSearch.js");
+
+const NOW = new Date().toISOString();
+
+function frag(overrides) {
+  return {
+    id: "f", content: "c", topic: "t", keywords: ["k"], type: "fact",
+    importance: 0.7, created_at: NOW, valid_to: null,
+    agent_id: "default", workspace: null, ...overrides
+  };
+}
+
+function makeSearch({ l2Rows, l3Rows }) {
+  const search = Object.create(FragmentSearch.prototype);
+  search.index = {
+    searchByKeywords: async () => [],
+    searchByTopic   : async () => [],
+    searchByType    : async () => [],
+    getRecent       : async () => [],
+    getCachedFragment: async () => null,
+    cacheFragment   : async () => {},
+    index           : async () => {}
+  };
+  search.store = {
+    searchByKeywords: async () => l2Rows.map(r => ({ ...r })),
+    searchByTopic   : async () => [],
+    getByIds        : async () => [],
+    searchBySemantic: async (...args) => {
+      semanticCalls.push({ kind: "semantic" });
+      return l3Rows.map(r => ({ ...r }));
+    },
+    incrementAccess : () => {},
+    touchLinked     : async () => {}
+  };
+  search.embeddingCache = { get: async () => null, set: () => {} };
+  search._morphemeIndex = { textToMorphemeVector: async () => null };
+  return search;
+}
+
+beforeEach(() => { semanticCalls = []; });
+
+describe("keywords-only L3 시맨틱 보조", () => {
+  it("text 없는 keywords 쿼리에서 L3 결과가 병합되고 searchPath에 L3kw가 남는다", async () => {
+    const search = makeSearch({
+      l2Rows: [frag({ id: "l2-hit" })],
+      l3Rows: [frag({ id: "l3-only", content: "content 수신 상한 4000자" })]
+    });
+
+    const result = await search.search({
+      keywords   : ["contentGuard", "4000자"],
+      contextText: "content 길이 게이트 이력",
+      agentId    : "default",
+      tokenBudget: 5000
+    });
+
+    const ids = new Set(result.fragments.map(f => f.id));
+    assert.ok(ids.has("l2-hit"), "L2 결과 유실");
+    assert.ok(ids.has("l3-only"), "L3 보조 결과 미병합");
+    assert.match(result.searchPath, /L3kw:\d+/);
+    assert.ok(semanticCalls.some(c => c.kind === "embed"), "임베딩 미호출");
+  });
+
+  it("합성 텍스트는 keywords와 contextText를 모두 포함한다", async () => {
+    const search = makeSearch({ l2Rows: [], l3Rows: [] });
+    await search.search({
+      keywords   : ["alpha", "beta"],
+      contextText: "gamma delta",
+      agentId    : "default",
+      tokenBudget: 1000
+    });
+    const embed = semanticCalls.find(c => c.kind === "embed");
+    assert.ok(embed, "임베딩 미호출");
+    assert.match(embed.text, /alpha/);
+    assert.match(embed.text, /gamma/);
+  });
+
+  it("중복 ID는 L2 결과가 우선한다", async () => {
+    const search = makeSearch({
+      l2Rows: [frag({ id: "dup", importance: 0.9 })],
+      l3Rows: [frag({ id: "dup", importance: 0.1 })]
+    });
+    const result = await search.search({
+      keywords: ["k"], agentId: "default", tokenBudget: 5000
+    });
+    const dups = result.fragments.filter(f => f.id === "dup");
+    assert.equal(dups.length, 1);
+    assert.equal(dups[0].importance, 0.9);
+  });
+});

--- a/tests/unit/mcp-handler-batch-json.test.js
+++ b/tests/unit/mcp-handler-batch-json.test.js
@@ -7,7 +7,7 @@
  * batch_remember / memory_consolidate 가 커스텀 SSE 경로가 아니라
  * 일반 _dispatchAndRespond(sendJSON) 경로로 처리되는지 검증.
  */
-import { test, describe, beforeEach, mock } from "node:test";
+import { test, describe, beforeEach, it, mock } from "node:test";
 import assert from "node:assert/strict";
 
 const sendJSONFn        = mock.fn(async () => {});
@@ -52,5 +52,22 @@ describe("mcp-handler batch_remember routing", () => {
 
     assert.equal(sendJSONFn.mock.callCount(), 1, "표준 JSON 응답 경로 사용");
     assert.equal(writeSSEEventFn.mock.callCount(), 0, "커스텀 SSE 프레임 미사용");
+  });
+});
+
+describe("JSON parse 오류 message 위치 정보", () => {
+  it("SyntaxError 메시지가 -32700 message에 포함된다", async () => {
+    const { buildParseErrorMessage } = await import("../../lib/handlers/mcp-handler.js");
+    let parseErr = null;
+    try {
+      JSON.parse('{"fragments":[{"content":"\\ud5cx"}]}');
+    } catch (e) {
+      parseErr = e;
+    }
+    assert.ok(parseErr instanceof SyntaxError);
+
+    const message = buildParseErrorMessage(parseErr);
+    assert.match(message, /^Parse error: /);
+    assert.match(message, /position|Unexpected|Bad/i);
   });
 });

--- a/tests/unit/mcp-protocol-version.test.js
+++ b/tests/unit/mcp-protocol-version.test.js
@@ -48,7 +48,12 @@ function checkProtocolVersion({ method, protoHeader, sessionNegotiated }) {
   }
 
   if (protoHeader && sessionNegotiated && sessionNegotiated !== protoHeader) {
-    return { status: 400, message: "Protocol version mismatch", effectiveVersion };
+    return {
+      status : 400,
+      message: `Protocol version mismatch: session negotiated ${sessionNegotiated} but request sent ${protoHeader}. Re-initialize the session.`,
+      data   : { negotiatedVersion: sessionNegotiated, receivedVersion: protoHeader, action: "reinitialize" },
+      effectiveVersion
+    };
   }
 
   return { status: 200, message: null, effectiveVersion };
@@ -117,8 +122,11 @@ describe("MCP-Protocol-Version 헤더 검증 (Phase 2c-3)", () => {
       protoHeader      : "2025-03-26",
       sessionNegotiated: "2025-06-18"
     });
-    assert.strictEqual(result.status, 400);
-    assert.strictEqual(result.message, "Protocol version mismatch");
+    assert.equal(result.status, 400);
+    assert.match(result.message, /Re-initialize the session/);
+    assert.equal(result.data.action, "reinitialize");
+    assert.equal(result.data.negotiatedVersion, "2025-06-18");
+    assert.equal(result.data.receivedVersion, "2025-03-26");
   });
 
   it("TC6: initialize 요청은 헤더 검증 생략 (항상 통과)", () => {

--- a/tests/unit/reflect-workspace-schema.test.js
+++ b/tests/unit/reflect-workspace-schema.test.js
@@ -1,0 +1,23 @@
+/**
+ * reflect 스키마 workspace 파라미터 노출 검증
+ *
+ * 작성자: 최진호
+ * 작성일: 2026-07-26
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { reflectDefinition } from "../../lib/tools/memory-schemas.js";
+
+describe("reflect 스키마 workspace", () => {
+  it("inputSchema.properties에 workspace가 노출된다", () => {
+    const props = reflectDefinition.inputSchema.properties;
+    assert.ok(props.workspace, "workspace 프로퍼티가 스키마에 없음");
+    assert.equal(props.workspace.type, "string");
+  });
+
+  it("workspace 설명이 미지정 시 default_workspace 폴백을 명시한다", () => {
+    const desc = reflectDefinition.inputSchema.properties.workspace.description;
+    assert.match(desc, /default_workspace/);
+  });
+});

--- a/tests/unit/search-event-recorder.test.js
+++ b/tests/unit/search-event-recorder.test.js
@@ -130,6 +130,12 @@ describe("buildSearchEvent", () => {
         assert.strictEqual(event.l3_count, 8);
     });
 
+    it("keywords 폴백 보조 세그먼트 L3kw:N도 l3_count로 집계된다", () => {
+        const event = buildSearchEvent({}, [], { searchPath: "L1:12 → L2:7 → L3kw:4" });
+        assert.strictEqual(event.l2_count, 7);
+        assert.strictEqual(event.l3_count, 4);
+    });
+
     it("RRF 포함 경로에서 used_rrf가 true이다", () => {
         const event = buildSearchEvent({}, [], { searchPath: "L1:3 → L2:7 → RRF" });
         assert.strictEqual(event.used_rrf, true);


### PR DESCRIPTION
## 변경 요약

1. keywords-only recall 폴백에 L3 시맨틱 보조 경로를 병렬 결합. 저장 keywords 배열에 없는 용어도 content 기반으로 회수된다. `MEMENTO_KEYWORD_SEMANTIC_FALLBACK=false`로 비활성 가능.
2. 검색 이벤트 l3_count가 폴백 보조 세그먼트(L3kw)도 집계하도록 보정.
3. reflect 스키마에 workspace 파라미터 노출 (#25). 프로세서는 기존에 이미 지원.
4. batch_remember fragments 문자열 입력 시 원인을 명시한 오류 메시지 분리.
5. JSON 파싱 실패 응답에 파서 위치 정보 보존.
6. 세션 protocol 불일치 응답에 재협상 안내 data 추가 (#23 증상 3).

## 테스트

- 신규 unit 3파일 + 기존 3파일 확장, 전체 스위트 2254건 실패 0.
- keywords-only 경로의 병렬 결합으로 지연 영향은 임베딩 1회분이며 플래그로 제어 가능.

Refs #23, #25