### PR TITLE
recall 정확 키워드 우선순위 보장 및 keywords 보조 경로 경량화

### DIFF
--- a/config/memory.js
+++ b/config/memory.js
@@ -141,7 +141,9 @@ export const MEMORY_CONFIG = {
     limit          : 30,
     /** text 없는 keywords-only 쿼리에서 L3 시맨틱 보조 실행 여부.
      *  L1/L2는 저장 keywords 배열만 보므로 content 매칭은 이 경로가 유일하다. */
-    keywordFallback: process.env.MEMENTO_KEYWORD_SEMANTIC_FALLBACK !== "false"
+    keywordFallback: process.env.MEMENTO_KEYWORD_SEMANTIC_FALLBACK !== "false",
+    /** keywords 보조 L3 실행 상한(ms). 초과 시 빈 배열로 대체해 응답 지연을 차단한다. */
+    keywordFallbackTimeoutMs: envInt("MEMENTO_KEYWORD_FALLBACK_TIMEOUT_MS", 1500, 100, 60000)
   },
   /** 파편 GC 정책 */
   gc: {

--- a/config/memory.js
+++ b/config/memory.js
@@ -30,6 +30,9 @@ export const MEMORY_CONFIG = {
     lexicalLinkedMultiplier  : 0.5,  // includeLinks 파편의 lexical 가중치 감쇠
     lexicalSaturation        : 8,    // lexicalMatchScore log 정규화 분모
     unrerankedBaseDiscount   : 0.85, // rerankerScore 미보유 파편 base에 적용하는 페널티 (reranking 미검증 신호)
+    /** keywords-only 정확 일치 가산. semantic 최대 기여(semanticWeight)보다 크게 잡아
+     *  유사도 분포가 극단적인 임베딩 환경에서도 정확 히트의 우위를 보장한다. */
+    exactKeywordBoost: 0.35,
   },
   /** stale 검증 주기 (일) */
   staleThresholds: {

--- a/config/memory.js
+++ b/config/memory.js
@@ -33,6 +33,10 @@ export const MEMORY_CONFIG = {
     /** keywords-only 정확 일치 가산. semantic 최대 기여(semanticWeight)보다 크게 잡아
      *  유사도 분포가 극단적인 임베딩 환경에서도 정확 히트의 우위를 보장한다. */
     exactKeywordBoost: 0.35,
+    /** 절단 슬롯 보장: exact 히트는 budget의 exactSlotShare까지, L3kw supplement는
+     *  semanticSlotShare까지 우선 확보한다(둘 다 무제한 아님 — 일반 키워드 독점 방지). */
+    exactSlotShare: 0.5,
+    semanticSlotShare: 0.25,
   },
   /** stale 검증 주기 (일) */
   staleThresholds: {

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -45,7 +45,8 @@
 | MEMENTO_REMEMBER_ATOMIC | false | When true, atomizes the quota check + INSERT in remember() into a single transaction. Sequence: BEGIN → api_keys FOR UPDATE (quota re-validation) → INSERT → COMMIT, fully eliminating TOCTOU. false (default) performs only a pre-check and is appropriate for environments with low concurrent request volume |
 | MEMENTO_CASE_BACKPROP_ENABLED | false | When true, enables CaseRewardBackprop, which back-propagates tool_feedback reward signals along case_id fragment chains. Adjust importance scores of cause fragments based on outcome quality |
 | MEMENTO_STORAGE | pgvector | Storage adapter selection. `pgvector` (default, PostgreSQL + pgvector). Additional adapters can be registered in `lib/storage/`. Changing this value requires all fragments to be re-indexed in the target backend |
-| MEMENTO_KEYWORD_SEMANTIC_FALLBACK | true | Set `false` to disable the L3 semantic supplement for keywords-only recall queries without text. When active, one embedding of the synthesized keywords(+contextText) text runs in parallel with L2, recovering fragments whose stored keywords lack the query terms via content matching |
+| MEMENTO_KEYWORD_SEMANTIC_FALLBACK | true | Set `false` to disable the L3 semantic supplement for keywords-only recall queries without text. When active, one embedding of the normalized keywords text runs in parallel with L2, recovering fragments whose stored keywords lack the query terms via content matching |
+| MEMENTO_KEYWORD_FALLBACK_TIMEOUT_MS | 1500 | Upper bound (ms, clamped 100-60000) for the keyword-supplement L3 run. On timeout it resolves to an empty result and leaves `L3kw:timeout` in searchPath |
 | MEMENTO_CONTEXT_ANCHOR_LIMIT | 10 | Maximum number of anchor (isAnchor) fragments always included in context responses. Clamped to 1-30; falls back to 10 on parse failure. Anchors are not trimmed by tokenBudget, so this count cap is the only injection limit |
 | MEMENTO_RECALL_MIN_SIM_FLOOR | (unset) | Opt-in floor for the adaptive similarity threshold returned by `SearchParamAdaptor.getMinSimilarity`. Example: when set to `0.45`, the returned value is clamped to at least 0.45 even if the learned value is lower. Unset preserves the existing behavior |
 | MEMENTO_MORPHEME_TOKENIZER | local | Morpheme tokenizer path. `local` (default): routes to per-language CPU analyzers — garu-ko (Korean), natural PorterStemmer (English), @node-rs/jieba (Chinese), kuromoji (Japanese). `llm`: falls back to the LLM subprocess path (`MorphemeIndex._tokenizeViaLLM()`). |
@@ -350,7 +351,8 @@ export const MEMORY_CONFIG = {
   semanticSearch: {
     minSimilarity  : 0.4,        // L3 pgvector search minimum similarity (default 0.4)
     limit          : 30,         // L3 max return count
-    keywordFallback: true        // Run L3 semantic supplement for keywords-only queries without text (disable with MEMENTO_KEYWORD_SEMANTIC_FALLBACK=false)
+    keywordFallback: true,       // Run L3 semantic supplement for keywords-only queries without text (disable with MEMENTO_KEYWORD_SEMANTIC_FALLBACK=false)
+    keywordFallbackTimeoutMs: 1500 // Upper bound for the keyword-supplement L3 run (env MEMENTO_KEYWORD_FALLBACK_TIMEOUT_MS)
   },
   temperatureBoost: {
     warmWindowDays     : 7,      // Apply warmBoost to fragments accessed within this window

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,7 +45,8 @@
 | MEMENTO_REMEMBER_ATOMIC | false | true 시 remember()의 quota check + INSERT를 단일 트랜잭션으로 원자화. BEGIN → api_keys FOR UPDATE(quota 재검증) → INSERT → COMMIT 순서로 TOCTOU를 완전 차단. false(기본)는 선제 quota check만 수행하며 동시 요청이 드문 환경에 적합 |
 | MEMENTO_CASE_BACKPROP_ENABLED | false | true 시 CaseRewardBackprop 활성화. case verification 이벤트마다 증거 파편 importance를 자동 역전파. 비활성 시 호출 자체가 no-op(DB·메트릭 영향 0). DAG 일관성 베이스라인 확보 후 활성화 권장 |
 | MEMENTO_STORAGE | pgvector | storage 어댑터 선택. `pgvector`(기본, PgVectorStore) 또는 `sqlite-vec`(SqliteVecStore). 변경 시 서버 재시작 필요 |
-| MEMENTO_KEYWORD_SEMANTIC_FALLBACK | true | `false` 설정 시 text 없는 keywords-only recall의 L3 시맨틱 보조 경로를 비활성화. 활성 시 keywords(+contextText) 합성 텍스트 임베딩 1회가 L2와 병렬 수행되어 저장 keywords에 없는 용어도 content 기반으로 회수된다 |
+| MEMENTO_KEYWORD_SEMANTIC_FALLBACK | true | `false` 설정 시 text 없는 keywords-only recall의 L3 시맨틱 보조 경로를 비활성화. 활성 시 정규화된 keywords 합성 텍스트 임베딩 1회가 L2와 병렬 수행되어 저장 keywords에 없는 용어도 content 기반으로 회수된다 |
+| MEMENTO_KEYWORD_FALLBACK_TIMEOUT_MS | 1500 | keywords 보조 L3 실행 상한(ms, 100~60000 클램프). 초과 시 빈 결과로 대체하고 searchPath에 `L3kw:timeout`을 남긴다 |
 | MEMENTO_CONTEXT_ANCHOR_LIMIT | 10 | context 응답에 항상 포함되는 앵커(isAnchor) 파편의 최대 개수. 1~30 범위로 클램프되며 파싱 실패 시 10. 앵커는 tokenBudget 절삭 대상이 아니므로 이 개수 상한이 유일한 주입량 제한이다 |
 | MEMENTO_RECALL_MIN_SIM_FLOOR | (없음) | `SearchParamAdaptor.getMinSimilarity`가 반환하는 적응형 임계값에 옵트인 하한을 강제. 예: `0.45` 설정 시 학습값이 0.45 미만이어도 0.45 반환. 미설정 시 기존 동작 그대로 |
 | MIGRATION_LINT_FROM | (없음) | `npm run lint:migrations` 검사 cutoff override. 지정 마이그레이션 번호 이후분만 검사. 미설정 시 전체 검사 |
@@ -381,7 +382,8 @@ export const MEMORY_CONFIG = {
   semanticSearch: {
     minSimilarity  : 0.4,        // L3 pgvector 검색 최소 유사도 (기본 0.4)
     limit          : 30,         // L3 반환 최대 건수
-    keywordFallback: true        // text 없는 keywords-only 쿼리에서 L3 시맨틱 보조 실행 (env MEMENTO_KEYWORD_SEMANTIC_FALLBACK=false로 비활성)
+    keywordFallback: true,       // text 없는 keywords-only 쿼리에서 L3 시맨틱 보조 실행 (env MEMENTO_KEYWORD_SEMANTIC_FALLBACK=false로 비활성)
+    keywordFallbackTimeoutMs: 1500 // keywords 보조 L3 실행 상한 (env MEMENTO_KEYWORD_FALLBACK_TIMEOUT_MS)
   },
   temperatureBoost: {
     warmWindowDays     : 7,      // 이 기간 내 접근 파편에 warmBoost 적용

--- a/lib/memory/read/FragmentSearch.js
+++ b/lib/memory/read/FragmentSearch.js
@@ -501,19 +501,33 @@ export class FragmentSearch {
     const kwFallbackOn = (MEMORY_CONFIG.semanticSearch?.keywordFallback ?? true) &&
                           EMBEDDING_ENABLED &&
                           Array.isArray(sq.keywords) && sq.keywords.length > 0;
-    const synthText    = kwFallbackOn
-      ? [sq.keywords.join(" "), sq.contextText].filter(Boolean).join(" ")
+    /** 결정적 캐시 키: 소문자·중복 제거·정렬. contextText는 임베딩 입력에서 제외해
+     *  호출마다 달라지는 텍스트로 인한 캐시 미스를 없앤다(회수 유지는 실측 확인됨). */
+    const synthText = kwFallbackOn
+      ? [...new Set(sq.keywords.map(k => String(k).toLowerCase().trim()))].sort().join(" ")
       : null;
-    const l3Task       = kwFallbackOn
-      ? (async () => {
-          const start   = Date.now();
-          const scope   = SearchScope.fromQuery(sq);
-          const results = await this._searchL3(
-            { ...sq, text: synthText }, agentId, keyId, timeRange, scope
-          );
-          layerLatency.l3Ms = Date.now() - start;
-          return results;
-        })()
+
+    /** 기존 L3 실행 클로저 — Promise.race의 승자/패자 어느 쪽이든 동일 참조로 재사용한다. */
+    const runL3 = async () => {
+      const start   = Date.now();
+      const scope   = SearchScope.fromQuery(sq);
+      const results = await this._searchL3(
+        { ...sq, text: synthText, _skipMorpheme: true }, agentId, keyId, timeRange, scope
+      );
+      layerLatency.l3Ms = Date.now() - start;
+      return results;
+    };
+
+    let l3TimedOut  = false;
+    const timeoutMs = MEMORY_CONFIG.semanticSearch?.keywordFallbackTimeoutMs ?? 1500;
+    const l3Task    = kwFallbackOn
+      ? Promise.race([
+          runL3(),
+          new Promise(resolve => setTimeout(() => {
+            l3TimedOut = true;
+            resolve([]);
+          }, timeoutMs).unref?.())
+        ])
       : Promise.resolve([]);
 
     const [[l2Results, temporalResults = []], l3Results] = await Promise.all([
@@ -552,6 +566,8 @@ export class FragmentSearch {
         searchPath.push(`L3kw:${supplement.length}`);
         combined.push(...supplement);
       }
+    } else if (l3TimedOut) {
+      searchPath.push("L3kw:timeout");
     }
 
     return combined;
@@ -732,8 +748,9 @@ export class FragmentSearch {
       const adaptedSim    = await (query._adaptedSimPromise ?? Promise.resolve(null));
       const minSimilarity = adaptedSim ?? cfgSim ?? 0.35;
 
-      /** 기본 시맨틱 검색과 morpheme 보강 검색을 병렬 실행한다. */
-      const morphemeProbe = (async () => {
+      /** 기본 시맨틱 검색과 morpheme 보강 검색을 병렬 실행한다.
+       *  _skipMorpheme(keywords 합성 텍스트 등 형태소 분석 무의미한 입력)은 즉시 [] 반환. */
+      const morphemeProbe = query._skipMorpheme === true ? Promise.resolve([]) : (async () => {
         try {
           const morphemeVec = await this._morphemeIndex.textToMorphemeVector(query.text);
           if (!morphemeVec) return [];

--- a/lib/memory/read/FragmentSearch.js
+++ b/lib/memory/read/FragmentSearch.js
@@ -192,8 +192,8 @@ export class FragmentSearch {
     const trimmed     = this._trimToTokenBudget(diversified, sq.tokenBudget);
     const totalTokens = this._estimateTokens(trimmed);
 
-    /** I-1: _rrfScore 내부 필드를 MCP 응답에서 제거. _kwExact는 절단 전 랭킹 전용 내부 신호. */
-    let clean = trimmed.map(({ _rrfScore, _kwExact, ...rest }) => rest);
+    /** I-1: _rrfScore 내부 필드를 MCP 응답에서 제거. _kwExact·_kwSupplement는 절단 전 랭킹·슬롯 전용 내부 신호. */
+    let clean = trimmed.map(({ _rrfScore, _kwExact, _kwSupplement, ...rest }) => rest);
 
     /** valid_to 필터: L1/HotCache/getByIds 경로를 포함한 모든 결과에 적용 */
     if (!sq.includeSuperseded) {
@@ -548,6 +548,7 @@ export class FragmentSearch {
       const seen = new Set(combined.map(f => f.id));
       const supplement = l3Results.filter(f => !seen.has(f.id));
       if (supplement.length > 0) {
+        for (const f of supplement) f._kwSupplement = true;
         searchPath.push(`L3kw:${supplement.length}`);
         combined.push(...supplement);
       }
@@ -902,17 +903,50 @@ export class FragmentSearch {
      * 토큰 예산에 맞춰 절삭
      */
   _trimToTokenBudget(fragments, tokenBudget) {
-    const result   = [];
-    let usedTokens = 0;
+    const cost = (f) => f.estimated_tokens || countTokens(f.content || "");
+    const { exactSlotShare = 0.5, semanticSlotShare = 0.25 } = MEMORY_CONFIG.ranking ?? {};
 
-    for (const f of fragments) {
-      const cost = f.estimated_tokens || countTokens(f.content || "");
-      if (usedTokens + cost > tokenBudget) break;
-      usedTokens += cost;
-      result.push(f);
+    /** 태그가 전무하면(예: text 경로) 기존 단순 절단 유지 */
+    const hasTags = fragments.some(f => f._kwExact === true || f._kwSupplement === true);
+    if (!hasTags) {
+      const result   = [];
+      let usedTokens = 0;
+      for (const f of fragments) {
+        const c = cost(f);
+        if (usedTokens + c > tokenBudget) break;
+        usedTokens += c;
+        result.push(f);
+      }
+      return result;
     }
 
-    return result;
+    /** pass 1: 정확 일치 — budget의 exactSlotShare 상한까지 선점 */
+    const picked = new Set();
+    let used     = 0;
+    for (const f of fragments) {
+      if (f._kwExact !== true) continue;
+      const c = cost(f);
+      if (used + c > tokenBudget * exactSlotShare) break;
+      used += c; picked.add(f.id);
+    }
+    /** pass 2: L3kw supplement — semanticSlotShare 몫 보장 */
+    let semUsed = 0;
+    for (const f of fragments) {
+      if (picked.has(f.id) || f._kwSupplement !== true) continue;
+      const c = cost(f);
+      if (semUsed + c > tokenBudget * semanticSlotShare) break;
+      if (used + c > tokenBudget) break;
+      used += c; semUsed += c; picked.add(f.id);
+    }
+    /** pass 3: 잔여 예산 — 점수 순서대로 경쟁 */
+    for (const f of fragments) {
+      if (picked.has(f.id)) continue;
+      const c = cost(f);
+      if (used + c > tokenBudget) continue;
+      used += c; picked.add(f.id);
+    }
+    /** 원래 점수 순서 유지한 채 선정분만 반환 */
+    return fragments.filter(f => picked.has(f.id));
   }
 
   /**

--- a/lib/memory/read/FragmentSearch.js
+++ b/lib/memory/read/FragmentSearch.js
@@ -192,8 +192,8 @@ export class FragmentSearch {
     const trimmed     = this._trimToTokenBudget(diversified, sq.tokenBudget);
     const totalTokens = this._estimateTokens(trimmed);
 
-    /** I-1: _rrfScore 내부 필드를 MCP 응답에서 제거 */
-    let clean = trimmed.map(({ _rrfScore, ...rest }) => rest);
+    /** I-1: _rrfScore 내부 필드를 MCP 응답에서 제거. _kwExact는 절단 전 랭킹 전용 내부 신호. */
+    let clean = trimmed.map(({ _rrfScore, _kwExact, ...rest }) => rest);
 
     /** valid_to 필터: L1/HotCache/getByIds 경로를 포함한 모든 결과에 적용 */
     if (!sq.includeSuperseded) {
@@ -521,12 +521,24 @@ export class FragmentSearch {
       l3Task
     ]);
     searchPath.push(`L2:${l2Results.length}`);
+
+    /** keywords-only 정확 일치 태그: L2/HotCache 결과에 부여한다.
+     *  L3 supplement는 정의상 semantic 보조이므로 태그 대상에서 제외한다. */
+    const queryKw = (sq.keywords ?? []).map(k => String(k).toLowerCase());
+    const tagExact = (rows) => {
+      for (const f of rows) {
+        const fragKw = (f.keywords ?? []).map(k => String(k).toLowerCase());
+        f._kwExact   = queryKw.length > 0 && queryKw.every(k => fragKw.includes(k));
+      }
+      return rows;
+    };
+
     const combined = [];
     if (l2Results.length > 0) {
-      combined.push(...l2Results);
+      combined.push(...tagExact(l2Results));
     }
     if (cached.length > 0) {
-      combined.push(...cached);
+      combined.push(...tagExact(cached));
     }
     if (temporalResults.length > 0) {
       searchPath.push(`Temporal:${temporalResults.length}`);
@@ -793,9 +805,15 @@ export class FragmentSearch {
 
     const similarity = fragment.similarity || fragment._rrfScore || 0;
 
+    /** keywords-only 정확 일치 가산: 절단 전 랭킹에서 정확 히트의 우위를 보장한다. */
+    const exactBoost = fragment._kwExact === true
+      ? (config.ranking.exactKeywordBoost ?? 0.35)
+      : 0;
+
     return effectiveImp * (importanceWeight || 0.4)
          + proximity    * (recencyWeight    || 0.3)
-         + similarity   * (semanticWeight   || 0.3);
+         + similarity   * (semanticWeight   || 0.3)
+         + exactBoost;
   }
 
   /**
@@ -816,6 +834,7 @@ export class FragmentSearch {
       } else {
         const existing = seen.get(f.id);
         if (f.similarity && (!existing.similarity || f.similarity > existing.similarity)) {
+          if (existing._kwExact === true) f._kwExact = true;
           seen.set(f.id, f);
         }
       }

--- a/lib/symbolic/rules/v1/explain.js
+++ b/lib/symbolic/rules/v1/explain.js
@@ -57,7 +57,8 @@ export function buildReasonCodes(fragment, searchContext = {}) {
   }
 
   /** L3 pgvector 또는 HotCache(L1) 는 둘 다 semantic layer 에 속한다 */
-  if (hasLayerTag(searchPath, "L3:") || hasLayerTag(searchPath, "HotCache:")) {
+  if (hasLayerTag(searchPath, "L3:") || hasLayerTag(searchPath, "HotCache:") ||
+      hasLayerTag(searchPath, "L3kw:")) {
     reasons.push({
       code       : "semantic_similarity",
       detail     : "L3 pgvector 임베딩 유사도",

--- a/tests/unit/keyword-fallback-semantic.test.js
+++ b/tests/unit/keyword-fallback-semantic.test.js
@@ -115,18 +115,18 @@ describe("keywords-only L3 시맨틱 보조", () => {
     assert.ok(semanticCalls.some(c => c.kind === "embed"), "임베딩 미호출");
   });
 
-  it("합성 텍스트는 keywords와 contextText를 모두 포함한다", async () => {
+  it("합성 텍스트는 정규화된 keywords만 포함하고 contextText는 제외한다", async () => {
     const search = makeSearch({ l2Rows: [], l3Rows: [] });
     await search.search({
-      keywords   : ["alpha", "beta"],
+      keywords   : ["Beta", "alpha", "ALPHA", " beta "],
       contextText: "gamma delta",
       agentId    : "default",
       tokenBudget: 1000
     });
     const embed = semanticCalls.find(c => c.kind === "embed");
     assert.ok(embed, "임베딩 미호출");
-    assert.match(embed.text, /alpha/);
-    assert.match(embed.text, /gamma/);
+    assert.equal(embed.text, "alpha beta", "소문자·중복 제거·정렬된 keywords만 기대");
+    assert.doesNotMatch(embed.text, /gamma/, "contextText는 합성 텍스트에서 제외되어야 함");
   });
 
   it("중복 ID는 L2 결과가 우선한다", async () => {

--- a/tests/unit/kw-exact-rank.test.js
+++ b/tests/unit/kw-exact-rank.test.js
@@ -1,0 +1,85 @@
+/**
+ * keywords-only 정확 일치 랭킹 가산 검증
+ *
+ * 작성자: 최진호
+ * 작성일: 2026-07-27
+ *
+ * 이슈 #30: keywords-only recall에서 정확 키워드 히트가 semantic 보조(supplement)
+ * 결과에 순위가 밀리는 구조 결함을 재현하고, _kwExact 태그 + 가산항으로 방지되는지 검증한다.
+ * 또한 _deduplicate에서 similarity 우선 교체 시 _kwExact 증거가 유실되지 않는지 검증한다.
+ */
+
+import { describe, it } from "node:test";
+import assert           from "node:assert/strict";
+
+import { FragmentSearch } from "../../lib/memory/read/FragmentSearch.js";
+
+const NOW = Date.now();
+
+/**
+ * 이슈 #30 시나리오의 정확 히트 파편: 방금 생성, importance 0.7, similarity 없음.
+ */
+function exactHitFragment(id) {
+  return {
+    id,
+    content    : "정확 히트",
+    keywords   : ["alpha", "beta"],
+    importance : 0.7,
+    created_at : new Date(NOW).toISOString(),
+    _kwExact   : true
+  };
+}
+
+/**
+ * L3kw supplement 파편: importance 0.8, 15일 경과, similarity 0.6, ema 부스트.
+ * _kwExact 미태깅(정의상 semantic).
+ */
+function supplementFragment(id) {
+  return {
+    id,
+    content       : "보조 결과",
+    keywords      : ["gamma"],
+    importance    : 0.8,
+    created_at    : new Date(NOW - 15 * 86400000).toISOString(),
+    similarity    : 0.6,
+    ema_activation: 10
+  };
+}
+
+describe("keywords-only 정확 일치 랭킹 가산", () => {
+  it("_deduplicate 결과에서 정확 히트가 supplement 다수보다 1위로 정렬된다", () => {
+    const search = Object.create(FragmentSearch.prototype);
+
+    const fragments = [
+      exactHitFragment("exact-hit"),
+      supplementFragment("supp-1"),
+      supplementFragment("supp-2"),
+      supplementFragment("supp-3")
+    ];
+
+    const result = search._deduplicate(fragments, 0, NOW);
+
+    assert.equal(result[0].id, "exact-hit", "정확 히트가 1위로 정렬되지 않음");
+  });
+
+  it("dedup 병합 시 similarity 높은 사본이 채택돼도 _kwExact 증거가 보존된다", () => {
+    const search = Object.create(FragmentSearch.prototype);
+
+    const existing = exactHitFragment("dup-1");
+    const l3Copy    = {
+      id        : "dup-1",
+      content   : "L3 사본",
+      keywords  : ["alpha", "beta"],
+      importance: 0.7,
+      created_at: new Date(NOW).toISOString(),
+      similarity: 0.6
+    };
+
+    const result = search._deduplicate([existing, l3Copy], 0, NOW);
+    const merged  = result.find(f => f.id === "dup-1");
+
+    assert.ok(merged, "병합된 파편 미발견");
+    assert.equal(merged.similarity, 0.6, "similarity 높은 L3 사본이 채택되지 않음");
+    assert.equal(merged._kwExact, true, "_kwExact 증거가 dedup 병합 중 유실됨");
+  });
+});

--- a/tests/unit/kw-fallback-timeout.test.js
+++ b/tests/unit/kw-fallback-timeout.test.js
@@ -1,0 +1,156 @@
+/**
+ * keywords 보조 L3 실행 상한(timeout) 검증
+ *
+ * 작성자: 최진호
+ * 작성일: 2026-07-27
+ *
+ * L3 시맨틱 보조가 keywordFallbackTimeoutMs를 초과하면 supplement는
+ * 빈 배열로 취급되고 searchPath에 L3kw:timeout이 남아야 한다.
+ */
+
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+
+let semanticCalls = [];
+
+mock.module("../../lib/redis.js", {
+  namedExports: { redisClient: { status: "stub" } }
+});
+
+mock.module("../../lib/logger.js", {
+  namedExports: {
+    logDebug: mock.fn(), logInfo: mock.fn(), logWarn: mock.fn(), logError: mock.fn()
+  }
+});
+
+mock.module("../../lib/tools/embedding.js", {
+  namedExports: {
+    EMBEDDING_ENABLED      : true,
+    computeContentHash     : () => "hash",
+    generateBatchEmbeddings: async () => [],
+    generateEmbedding      : async (text) => {
+      semanticCalls.push({ kind: "embed", text });
+      return new Array(4).fill(0.1);
+    },
+    prepareTextForEmbedding: text => String(text ?? ""),
+    vectorToSql            : vector => `[${vector.join(",")}]`
+  }
+});
+
+mock.module("../../lib/memory/signals/SearchMetrics.js", {
+  namedExports: { getSearchMetrics: async () => ({ record: async () => {} }) }
+});
+
+mock.module("../../lib/memory/signals/SearchParamAdaptor.js", {
+  namedExports: { getSearchParamAdaptor: () => ({ getMinSimilarity: async () => null }) }
+});
+
+mock.module("../../lib/memory/read/SearchSideEffects.js", {
+  namedExports: { commitSearchSideEffects: async () => null }
+});
+
+mock.module("../../lib/memory/read/Reranker.js", {
+  namedExports: { isRerankerAvailable: () => false, rerank: async () => null }
+});
+
+const { FragmentSearch } = await import("../../lib/memory/read/FragmentSearch.js");
+const { MEMORY_CONFIG }  = await import("../../config/memory.js");
+
+const NOW = new Date().toISOString();
+
+function frag(overrides) {
+  return {
+    id: "f", content: "c", topic: "t", keywords: ["k"], type: "fact",
+    importance: 0.7, created_at: NOW, valid_to: null,
+    agent_id: "default", workspace: null, ...overrides
+  };
+}
+
+/**
+ * L3 시맨틱 검색이 delayMs 이후에만 응답하는 느린 store로 FragmentSearch를 구성한다.
+ */
+function makeSlowSearch({ l2Rows, l3Rows, delayMs }) {
+  const search = Object.create(FragmentSearch.prototype);
+  search.index = {
+    searchByKeywords : async () => [],
+    searchByTopic    : async () => [],
+    searchByType     : async () => [],
+    getRecent        : async () => [],
+    getCachedFragment: async () => null,
+    cacheFragment    : async () => {},
+    index            : async () => {}
+  };
+  search.store = {
+    searchByKeywords: async () => l2Rows.map(r => ({ ...r })),
+    searchByTopic   : async () => [],
+    getByIds        : async () => [],
+    searchBySemantic: async (...args) => {
+      semanticCalls.push({ kind: "semantic" });
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+      return l3Rows.map(r => ({ ...r }));
+    },
+    incrementAccess: () => {},
+    touchLinked     : async () => {}
+  };
+  search.embeddingCache = { get: async () => null, set: () => {} };
+  search._morphemeIndex = {
+    textToMorphemeVector: async () => {
+      throw new Error("morphemeIndex는 _skipMorpheme=true일 때 절대 호출되면 안 된다");
+    }
+  };
+  return search;
+}
+
+describe("keywords 보조 L3 실행 상한", () => {
+  let originalTimeoutMs;
+
+  beforeEach(() => {
+    semanticCalls      = [];
+    originalTimeoutMs  = MEMORY_CONFIG.semanticSearch.keywordFallbackTimeoutMs;
+  });
+
+  afterEach(() => {
+    MEMORY_CONFIG.semanticSearch.keywordFallbackTimeoutMs = originalTimeoutMs;
+  });
+
+  it("L3 응답이 상한을 초과하면 supplement 없이 L3kw:timeout이 searchPath에 남는다", async () => {
+    MEMORY_CONFIG.semanticSearch.keywordFallbackTimeoutMs = 20;
+
+    const search = makeSlowSearch({
+      l2Rows : [frag({ id: "l2-hit" })],
+      l3Rows : [frag({ id: "l3-too-late", content: "타임아웃 이후 도착" })],
+      delayMs: 200
+    });
+
+    const result = await search.search({
+      keywords   : ["timeout", "probe"],
+      agentId    : "default",
+      tokenBudget: 5000
+    });
+
+    const ids = new Set(result.fragments.map(f => f.id));
+    assert.ok(ids.has("l2-hit"), "L2 결과는 유지되어야 함");
+    assert.ok(!ids.has("l3-too-late"), "타임아웃된 L3 결과가 병합되면 안 됨");
+    assert.doesNotMatch(result.searchPath, /L3kw:\d+/, "정상 L3kw 카운트 세그먼트가 남으면 안 됨");
+    assert.match(result.searchPath, /L3kw:timeout/, "L3kw:timeout 세그먼트 부재");
+  });
+
+  it("_skipMorpheme=true 전달 시 형태소 프로브를 생략한다", async () => {
+    MEMORY_CONFIG.semanticSearch.keywordFallbackTimeoutMs = 1500;
+
+    const search = makeSlowSearch({
+      l2Rows : [],
+      l3Rows : [frag({ id: "l3-only" })],
+      delayMs: 0
+    });
+
+    const result = await search.search({
+      keywords   : ["morph", "skip"],
+      agentId    : "default",
+      tokenBudget: 5000
+    });
+
+    const ids = new Set(result.fragments.map(f => f.id));
+    assert.ok(ids.has("l3-only"), "형태소 프로브 생략 경로에서도 기본 L3 결과는 병합돼야 함");
+  });
+});

--- a/tests/unit/kw-slot-trim.test.js
+++ b/tests/unit/kw-slot-trim.test.js
@@ -1,0 +1,81 @@
+/**
+ * 슬롯 보장 절단 검증
+ *
+ * 작성자: 최진호
+ * 작성일: 2026-07-27
+ *
+ * 이슈 #30: _trimToTokenBudget이 단순 prefix 절단(첫 초과 시 break)만 수행하여
+ * budget이 빡빡할 때 점수 우위인 supplement가 exact 히트·다른 supplement를 절단 전 밀어낼 수
+ * 있었다. _kwExact/_kwSupplement 슬롯 보장 3-pass 절단으로 방지되는지 검증한다.
+ */
+
+import { describe, it } from "node:test";
+import assert           from "node:assert/strict";
+
+import { FragmentSearch } from "../../lib/memory/read/FragmentSearch.js";
+
+describe("슬롯 보장 절단", () => {
+  it("점수 우위 일반 파편이 예산을 선점해도 정확 히트와 supplement가 생존한다", () => {
+    const search = Object.create(FragmentSearch.prototype);
+
+    /** 순위상 최우선(고득점) 이지만 태그 없는 일반 파편 — 예산 전체를 잠식할 크기 */
+    const general = { id: "general", content: "일반", estimated_tokens: 90 };
+    /** L3kw supplement — semanticSlotShare(25) 이내 */
+    const supplement = { id: "supp", content: "보조", estimated_tokens: 20, _kwSupplement: true };
+    /** keywords 정확 일치 — 순위는 가장 낮지만 exactSlotShare(50) 이내 */
+    const exact = { id: "exact", content: "정확", estimated_tokens: 40, _kwExact: true };
+
+    const result = search._trimToTokenBudget([general, supplement, exact], 100);
+    const ids    = result.map(f => f.id);
+
+    assert.ok(ids.includes("exact"), "정확 히트가 절단에서 생존하지 않음");
+    assert.ok(ids.includes("supp"), "supplement가 절단에서 전멸함");
+    assert.ok(!ids.includes("general"), "일반 파편이 예산을 선점해 슬롯 보장이 무력화됨");
+  });
+
+  it("정확 히트가 exactSlotShare(50%) 상한을 초과 점유하지 못한다", () => {
+    const search = Object.create(FragmentSearch.prototype);
+
+    const e1 = { id: "e1", content: "e1", estimated_tokens: 40, _kwExact: true };
+    /** 예산 잔여를 소비하는 태그 없는 필러 — pass 3이 e2를 되채우지 못하도록 함 */
+    const fillers = Array.from({ length: 6 }, (_, i) => ({
+      id: `g${i}`, content: "g", estimated_tokens: 10
+    }));
+    const e2 = { id: "e2", content: "e2", estimated_tokens: 40, _kwExact: true };
+
+    const result     = search._trimToTokenBudget([e1, ...fillers, e2], 100);
+    const exactCost   = result.filter(f => f._kwExact === true)
+      .reduce((sum, f) => sum + f.estimated_tokens, 0);
+
+    assert.ok(exactCost <= 50, `정확 히트 점유량(${exactCost})이 exactSlotShare 상한(50)을 초과함`);
+    assert.ok(!result.some(f => f.id === "e2"), "e2가 상한을 넘어 선점됨");
+  });
+
+  it("태그 없는 일반 경로(text)는 기존 단순 prefix 절단과 바이트 동일하다", () => {
+    const search = Object.create(FragmentSearch.prototype);
+
+    const fragments = [
+      { id: "t1", content: "t1", estimated_tokens: 40 },
+      { id: "t2", content: "t2", estimated_tokens: 40 },
+      { id: "t3", content: "t3", estimated_tokens: 40 }
+    ];
+
+    /** 기존 알고리즘 재구현: 첫 초과 시 즉시 break하는 prefix 절단 */
+    const legacyTrim = (frags, budget) => {
+      const out = [];
+      let used  = 0;
+      for (const f of frags) {
+        const c = f.estimated_tokens;
+        if (used + c > budget) break;
+        used += c;
+        out.push(f);
+      }
+      return out;
+    };
+
+    const expected = legacyTrim(fragments, 100);
+    const actual   = search._trimToTokenBudget(fragments, 100);
+
+    assert.deepEqual(actual, expected, "태그 부재 경로가 기존 절단과 달라짐");
+  });
+});


### PR DESCRIPTION
## 변경 요약

1. keywords-only recall에서 정확 키워드 일치 파편에 내부 증거 태그를 부여하고, 절단 이전 랭킹에 가산(`ranking.exactKeywordBoost`, 기본 0.35)한다. 중복 제거 시 증거가 보존된다.
2. tokenBudget 절단을 슬롯 보장 방식으로 확장: 정확 일치는 예산의 50%까지 선점, 시맨틱 보조는 25% 몫을 보장, 잔여는 점수 경쟁. 태그가 없는 text/mixed 경로는 기존 절단과 동일하게 동작한다.
3. 보조 경로 질의를 정규화(소문자·중복 제거·정렬)해 임베딩 캐시 적중률을 높이고, 이 경로의 형태소 프로브를 생략하며, 실행 상한(`MEMENTO_KEYWORD_FALLBACK_TIMEOUT_MS`, 기본 1500ms)을 도입한다. 초과 시 보조 없이 즉시 반환하고 searchPath에 `L3kw:timeout`을 남긴다.
4. explanations의 semantic_similarity 사유가 `L3kw:` 세그먼트에도 부여되도록 정리.

## 테스트

- 신규 unit 3파일 + 기존 1파일 계약 갱신, 전체 스위트 2270건 실패 0.
- 이슈 재현 조건(고유사도 보조 다수 + 빡빡한 budget)에서 정확 히트 생존을 가산항과 슬롯로 이중 보장.

Refs #30