### PR TITLE
feat: add Antigravity CLI provider

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -348,7 +348,7 @@ tools/list 응답의 각 도구에 `meta` 필드가 포함된다.
 
 #### LLM Provider 체인 확장
 
-`LLM_PRIMARY` 및 `LLM_FALLBACKS`에 `codex-cli`, `copilot-cli`, `qwen-cli` 추가 지원.
+`LLM_PRIMARY` 및 `LLM_FALLBACKS`에 `agy-cli`, `codex-cli`, `copilot-cli`, `qwen-cli`, `opencode-cli` 추가 지원.
 
 예시 `.env`:
 ```
@@ -356,7 +356,7 @@ LLM_PRIMARY=gemini-cli
 LLM_FALLBACKS='[{"provider":"codex-cli"},{"provider":"copilot-cli"},{"provider":"ollama","baseUrl":"https://ollama.com","apiKey":"...","model":"glm-5.1:cloud"}]'
 ```
 
-CLI provider는 API 키 불필요. 로컬 바이너리(`gemini`/`codex`/`copilot`) 설치 + 로그인만 필요.
+CLI provider는 API 키 불필요. 로컬 바이너리(`gemini`/`agy`/`codex`/`copilot`/`opencode`) 설치 + 로그인만 필요.
 
 #### 로컬 임베딩 Provider
 
@@ -1563,7 +1563,7 @@ recall 또는 context 응답의 `_meta.hints` 필드를 읽는다:
 
 ## LLM Provider Fallback
 
-Gemini CLI 외 `codex-cli`, `copilot-cli`, `qwen-cli` 포함 15개 이상의 외부 provider로 자동 fallback 가능. 설정: `LLM_PRIMARY=gemini-cli` (기본) + `LLM_FALLBACKS` JSON 배열. env 미설정 시 기존 Gemini CLI 단독 동작 유지. 형태소 분석은 기본적으로 로컬 CPU 분석기(MorphemeTokenizer)가 담당하며 LLM provider 체인을 사용하지 않는다(`MEMENTO_MORPHEME_TOKENIZER=llm` 설정 시에만 LLM 경로 활성화). 자세한 운영은 `docs/operations/llm-providers.md` 참조.
+Gemini CLI 외 `agy-cli`, `codex-cli`, `copilot-cli`, `qwen-cli`를 포함한 18개 provider로 자동 fallback 가능. 설정: `LLM_PRIMARY=gemini-cli` (기본) + `LLM_FALLBACKS` JSON 배열. env 미설정 시 기존 Gemini CLI 단독 동작 유지. 형태소 분석은 기본적으로 로컬 CPU 분석기(MorphemeTokenizer)가 담당하며 LLM provider 체인을 사용하지 않는다(`MEMENTO_MORPHEME_TOKENIZER=llm` 설정 시에만 LLM 경로 활성화). 자세한 운영은 `docs/operations/llm-providers.md` 참조.
 
 ## Symbolic Memory 활용 (opt-in)
 

--- a/docs/INSTALL.en.md
+++ b/docs/INSTALL.en.md
@@ -315,7 +315,7 @@ cp .env.example .env
 Additional environment variables:
 
 ```
-LLM_PRIMARY                   - Primary LLM provider (default: gemini-cli). Options: gemini-cli, codex, copilot, anthropic, etc.
+LLM_PRIMARY                   - Primary LLM provider (default: gemini-cli). Options: gemini-cli, agy-cli, codex-cli, opencode-cli, anthropic, etc.
 LLM_FALLBACKS                 - JSON array of fallback providers: [{"provider":"anthropic","apiKey":"...","model":"claude-opus-4-6"}]
 MEMENTO_REMEMBER_ATOMIC       - When true, atomizes quota check + INSERT in remember() into a single transaction to eliminate TOCTOU (default: false)
 MEMENTO_CASE_BACKPROP_ENABLED - When true, enables CaseRewardBackprop — reward back-propagation per case_id (default: false)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -282,7 +282,7 @@ COMPRESS_MIN_GROUP            - 압축 그룹 최소 크기 (기본: 3)
 CONSOLIDATE_INTERVAL_MS       - consolidate 주기 (기본: 3600000 = 1시간)
 ALLOWED_ORIGINS               - CORS 허용 Origin 목록 (쉼표 구분)
 RERANKER_MODEL                - in-process ONNX 모델 선택: minilm (기본, 영어 전용) 또는 bge-m3 (다국어, 비영어권 권장)
-LLM_PRIMARY                   - 주 LLM provider (기본: gemini-cli). gemini-cli, codex, copilot, anthropic 등
+LLM_PRIMARY                   - 주 LLM provider (기본: gemini-cli). gemini-cli, agy-cli, codex-cli, opencode-cli, anthropic 등
 LLM_FALLBACKS                 - JSON 배열. 각 원소: {"provider":"anthropic","apiKey":"...","model":"claude-opus-4-6"}
 MEMENTO_REMEMBER_ATOMIC       - true로 설정 시 remember() quota 체크+INSERT를 단일 트랜잭션으로 원자화 (기본: false)
 MEMENTO_CASE_BACKPROP_ENABLED - true로 설정 시 CaseRewardBackprop 활성화 — case_id 단위 reward 역전파 (기본: false)

--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -44,10 +44,11 @@
 | CLI | 설치 명령 | 용도 |
 |-----|---------|------|
 | gemini | `npm install -g @google/gemini-cli` | 기본 LLM provider (`LLM_PRIMARY=gemini-cli`) |
+| agy | Google Antigravity 공식 installer | Google Antigravity CLI provider (`LLM_PRIMARY=agy-cli`) |
 | codex | `npm install -g @openai/codex` | OpenAI Codex CLI fallback |
 | copilot | `npm install -g @githubnext/github-copilot-cli` | GitHub Copilot CLI fallback |
 
-각 CLI는 설치 후 별도 로그인이 필요하다(`gemini auth login`, `codex auth login`, `github-copilot-cli auth`). 미설치 시 해당 provider는 자동으로 건너뛰고 다음 fallback으로 전환된다.
+각 CLI는 설치 후 별도 로그인이 필요하다(`gemini auth login`, `agy`, `codex auth login`, `github-copilot-cli auth`). 미설치 또는 인증 실패 시 해당 provider는 다음 fallback으로 전환된다.
 
 ---
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -1076,7 +1076,7 @@ The `codex-cli` provider carries `model` / `timeoutMs` settings through to the a
 LLM_PRIMARY=gemini-cli
     |
     v
-[gemini-cli] -> fail -> [anthropic] -> fail -> [codex-cli] -> fail -> [copilot-cli] -> fail -> [qwen-cli] -> ...
+[gemini-cli] -> fail -> [agy-cli] -> fail -> [anthropic] -> fail -> [codex-cli] -> fail -> [copilot-cli] -> fail -> [qwen-cli] -> ...
 ```
 
 **codex-cli provider** (`lib/llm/providers/CodexCliProvider.js`):
@@ -1100,7 +1100,7 @@ LLM_PRIMARY=gemini-cli
 - Circuit breaker failure threshold (LLM_CB_FAILURE_THRESHOLD=5) and OPEN duration (LLM_CB_OPEN_DURATION_MS=60000) remain unchanged
 
 **Complete LLM_PRIMARY allowed values**:
-`gemini-cli`, `anthropic`, `openai`, `google-gemini-api`, `groq`, `openrouter`, `xai`, `ollama`, `vllm`, `deepseek`, `mistral`, `cohere`, `zai`, `codex-cli`, `copilot-cli`, `qwen-cli`
+`gemini-cli`, `agy-cli`, `anthropic`, `openai`, `google-gemini-api`, `groq`, `openrouter`, `xai`, `ollama`, `vllm`, `deepseek`, `mistral`, `cohere`, `zai`, `codex-cli`, `copilot-cli`, `qwen-cli`, `opencode-cli`
 
 ### Search Pipeline -- _suggestion Post-Processing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1079,7 +1079,7 @@ llmJson(prompt, options)
 LLM_PRIMARY=gemini-cli
     │
     ▼
-[gemini-cli] → 실패 → [anthropic] → 실패 → [codex-cli] → 실패 → [copilot-cli] → 실패 → [qwen-cli] → ...
+[gemini-cli] → 실패 → [agy-cli] → 실패 → [anthropic] → 실패 → [codex-cli] → 실패 → [copilot-cli] → 실패 → [qwen-cli] → ...
 ```
 
 **codex-cli provider** (`lib/llm/providers/CodexCliProvider.js`):
@@ -1103,7 +1103,7 @@ LLM_PRIMARY=gemini-cli
 - circuit breaker 실패 임계(LLM_CB_FAILURE_THRESHOLD=5), OPEN 지속(LLM_CB_OPEN_DURATION_MS=60000)은 기존과 동일
 
 **LLM_PRIMARY 허용값 전체 목록**:
-`gemini-cli`, `anthropic`, `openai`, `google-gemini-api`, `groq`, `openrouter`, `xai`, `ollama`, `vllm`, `deepseek`, `mistral`, `cohere`, `zai`, `codex-cli`, `copilot-cli`, `qwen-cli`
+`gemini-cli`, `agy-cli`, `anthropic`, `openai`, `google-gemini-api`, `groq`, `openrouter`, `xai`, `ollama`, `vllm`, `deepseek`, `mistral`, `cohere`, `zai`, `codex-cli`, `copilot-cli`, `qwen-cli`, `opencode-cli`
 
 ### 검색 파이프라인 — _suggestion 후처리
 

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -148,6 +148,8 @@ gemini-cli, **agy-cli**, anthropic, openai, google-gemini-api, groq, openrouter,
 [{"provider": "agy-cli", "model": "<model listed by agy models>", "timeoutMs": 40000}]
 ```
 
+Because `agy` treats tokens after `--print` as the prompt, AnchorMind invokes it as `--output-format text --mode plan --sandbox [--model MODEL] --print PROMPT`.
+
 On macOS launchd deployments, shell profiles are not loaded. Add `~/.local/bin` explicitly to the plist `PATH` so the service can find `agy`.
 
 **codex-cli**: Executes `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE`. Authenticates via `OPENAI_API_KEY` or the Codex CLI config file. `model` and `timeoutMs` in `LLM_FALLBACKS` are passed through to the actual CLI invocation:

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -141,7 +141,14 @@ The default slot limit for providers not listed is 10. When `LLM_CONCURRENCY` is
 
 ##### Supported Providers
 
-gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**, **qwen-cli**
+gemini-cli, **agy-cli**, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**, **qwen-cli**, **opencode-cli**
+
+**agy-cli**: Runs Google Antigravity CLI (`agy`) with `--print --output-format text --mode plan --sandbox`. AnchorMind uses the provider only for JSON transformations, so the CLI is constrained from editing files or approving tool calls. Antigravity authentication and the `agy` binary are required; `model` and `timeoutMs` are passed to the CLI invocation:
+```json
+[{"provider": "agy-cli", "model": "<model listed by agy models>", "timeoutMs": 40000}]
+```
+
+On macOS launchd deployments, shell profiles are not loaded. Add `~/.local/bin` explicitly to the plist `PATH` so the service can find `agy`.
 
 **codex-cli**: Executes `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE`. Authenticates via `OPENAI_API_KEY` or the Codex CLI config file. `model` and `timeoutMs` in `LLM_FALLBACKS` are passed through to the actual CLI invocation:
 ```json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,7 +136,14 @@ REDIS_ENABLED=true면 Redis에 상태 저장, 아니면 in-memory.
 
 ##### 지원 Provider 목록
 
-gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**, **qwen-cli**
+gemini-cli, **agy-cli**, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**, **qwen-cli**, **opencode-cli**
+
+**agy-cli**: Google Antigravity CLI(`agy`)를 `--print --output-format text --mode plan --sandbox` 제약으로 실행한다. AnchorMind의 LLM 변환은 JSON 응답만 사용하므로, provider는 파일 수정과 도구 승인을 하지 않는 plan/sandbox 경로만 사용한다. Antigravity 로그인과 `agy` 바이너리가 필요하며, `model`, `timeoutMs` 설정은 실제 CLI 호출에 전달된다:
+```json
+[{"provider": "agy-cli", "model": "<agy models에서 확인한 모델명>", "timeoutMs": 40000}]
+```
+
+macOS launchd로 서버를 실행하는 경우 셸 프로필을 읽지 않으므로, plist의 `PATH`에 `~/.local/bin`을 명시해 `agy`를 찾을 수 있게 해야 한다.
 
 **codex-cli**: `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE` 명령을 실행한다. `OPENAI_API_KEY` 또는 Codex CLI 설정 파일로 인증한다. `LLM_FALLBACKS`의 `model`, `timeoutMs` 설정이 provider config를 통해 실제 CLI 호출까지 전달된다:
 ```json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,8 @@ gemini-cli, **agy-cli**, anthropic, openai, google-gemini-api, groq, openrouter,
 [{"provider": "agy-cli", "model": "<agy models에서 확인한 모델명>", "timeoutMs": 40000}]
 ```
 
+실제 CLI는 `--print` 뒤의 모든 인자를 프롬프트로 처리하므로, AnchorMind는 `--output-format text --mode plan --sandbox [--model MODEL] --print PROMPT` 순서로 실행한다.
+
 macOS launchd로 서버를 실행하는 경우 셸 프로필을 읽지 않으므로, plist의 `PATH`에 `~/.local/bin`을 명시해 `agy`를 찾을 수 있게 해야 한다.
 
 **codex-cli**: `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE` 명령을 실행한다. `OPENAI_API_KEY` 또는 Codex CLI 설정 파일로 인증한다. `LLM_FALLBACKS`의 `model`, `timeoutMs` 설정이 provider config를 통해 실제 CLI 호출까지 전달된다:

--- a/docs/operations/llm-providers.md
+++ b/docs/operations/llm-providers.md
@@ -5,7 +5,7 @@
 
 ## 개요
 
-memento-mcp는 내부 LLM 호출(AutoReflect, MorphemeIndex, ConsolidatorGC, ContradictionDetector, MemoryEvaluator)에 16개 provider fallback chain을 지원한다. 기본값은 Gemini CLI 단독 사용으로 기존 동작 완전 보존.
+memento-mcp는 내부 LLM 호출(AutoReflect, MorphemeIndex, ConsolidatorGC, ContradictionDetector, MemoryEvaluator)에 18개 provider fallback chain을 지원한다. 기본값은 Gemini CLI 단독 사용으로 기존 동작 완전 보존.
 
 ## 활성화
 
@@ -30,13 +30,14 @@ LLM_FALLBACKS='[
 ```
 
 Gemini CLI 실패 시 codex-cli → anthropic → openai 순차 시도.
-CLI provider(`gemini-cli`, `codex-cli`, `copilot-cli`, `qwen-cli`)도 `LLM_FALLBACKS`의 `model`, `timeoutMs`를 provider config로 전달받는다.
+CLI provider(`gemini-cli`, `agy-cli`, `codex-cli`, `copilot-cli`, `qwen-cli`, `opencode-cli`)도 `LLM_FALLBACKS`의 `model`, `timeoutMs`를 provider config로 전달받는다.
 
 ## Provider별 필수 필드
 
 | Provider | apiKey | model | baseUrl | 기본 baseUrl |
 |----------|--------|-------|---------|-------------|
 | gemini-cli | - | - | - | (CLI 바이너리) |
+| agy-cli | - | 선택 | - | Antigravity CLI(`agy`) + 로그인 |
 | codex-cli | - | 선택 | - | (CLI 바이너리 + Codex 인증) |
 | copilot-cli | - | - | - | (CLI 바이너리 + GitHub Copilot 인증) |
 | qwen-cli | - | 선택 | - | (CLI 바이너리 + Qwen 인증) |
@@ -62,6 +63,7 @@ CLI provider(`gemini-cli`, `codex-cli`, `copilot-cli`, `qwen-cli`)도 `LLM_FALLB
 | chainKey / provider | 기본 슬롯 수 |
 |-|-|
 | gemini-cli | 1 |
+| agy-cli | 1 |
 | codex-cli | 1 |
 | copilot-cli | 1 |
 | qwen-cli | 1 |
@@ -183,7 +185,7 @@ LLM provider 관련 E2E 통합 테스트는 [tests/integration/README.md](../../
   - Google Gemini API: POST /v1beta/models/{model}:generateContent, API 키 URL 파라미터
   - Cohere: POST /v1/chat, preamble 필드, 최상위 text 응답
 - HTTP를 사용하지 않는 stdio / CLI 실행 경로일 때
-  - GeminiCliProvider, CodexCliProvider, CopilotCliProvider
+  - GeminiCliProvider, AgyCliProvider, CodexCliProvider, CopilotCliProvider
 
 이 경우 callText 또는 callJson을 직접 구현하고 circuit breaker 호출을 수동으로 포함해야 한다.
 
@@ -201,6 +203,7 @@ OpenAICompatibleProvider를 상속하면 callText 구현이 자동으로 제공�
 | Provider | 상속 클래스 | 경로 |
 |-|-|-|
 | GeminiCliProvider | LlmProvider | stdio, gemini CLI 바이너리 |
+| AgyCliProvider | LlmProvider | stdio, constrained Antigravity CLI |
 | CodexCliProvider | LlmProvider | stdio, codex CLI 바이너리 |
 | CopilotCliProvider | LlmProvider | stdio, gh copilot CLI 바이너리 |
 | AnthropicProvider | LlmProvider | POST /v1/messages, 고유 스키마 |
@@ -306,9 +309,10 @@ export class MyCustomProvider extends LlmProvider {
 
 ### 사용 가능한 provider 이름
 
-`listProviderNames()` 출력: `openai, anthropic, gemini, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, gemini-cli, codex-cli, copilot-cli, qwen-cli, opencode-cli`
+`listProviderNames()` 출력: `openai, anthropic, gemini, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, gemini-cli, agy-cli, codex-cli, copilot-cli, qwen-cli, opencode-cli`
 
 - `xai` = Grok (xAI API, `https://api.x.ai/v1`)
+- `agy-cli` = Google Antigravity CLI. `--print --mode plan --sandbox`로 실행되어 파일 수정과 도구 승인을 하지 않는다.
 - `opencode-cli` = OpenCode CLI (provider/model은 `model` 필드로 선택, 예: `"xiaomi/mimo-v2.5-pro"`)
 
 ### provider별 필수 의존성
@@ -318,6 +322,7 @@ export class MyCustomProvider extends LlmProvider {
 | `xai` (Grok) | `XAI_API_KEY` (또는 엔트리의 `apiKey`); `https://api.x.ai/v1` 접근 가능 | `isAvailable()` 실패 → 체인에서 제외 |
 | `opencode-cli` | `opencode` 바이너리가 `PATH`에 존재; 허용된 `model` (예: `xiaomi/*`) | 바이너리 없음 → 체인에서 제외 |
 | `gemini-cli` | `gemini` 바이너리가 `PATH`에 존재 | 바이너리 없음 → 체인에서 제외 |
+| `agy-cli` | `agy` 바이너리가 `PATH`에 존재하고 Antigravity 로그인 완료 | 바이너리 없음 → 체인에서 제외, 인증 실패 → 다음 fallback 시도 |
 | `codex-cli` / `copilot-cli` / `qwen-cli` | 해당 CLI 바이너리가 `PATH`에 존재 | 바이너리 없음 → 체인에서 제외 |
 | API providers (`anthropic`, `openai`, …) | 엔트리에 provider API 키 | 키 없음 → 체인에서 제외 |
 

--- a/lib/agy.js
+++ b/lib/agy.js
@@ -46,14 +46,15 @@ export async function isAgyCLIAvailable() {
  */
 export function buildAgyArgs(prompt, options = {}) {
   const args = [
-    "--print",
     "--output-format", "text",
     "--mode", "plan",
     "--sandbox"
   ];
 
   if (options.model) args.push("--model", options.model);
-  args.push(prompt);
+  // agy treats tokens after --print as the prompt, so all execution flags
+  // must precede it to prevent them from being interpreted as model input.
+  args.push("--print", prompt);
   return args;
 }
 

--- a/lib/agy.js
+++ b/lib/agy.js
@@ -1,0 +1,118 @@
+/**
+ * Google Antigravity CLI client for AnchorMind.
+ *
+ * The CLI runs in print-only, plan, and sandbox modes because this provider
+ * is used only for JSON generation from memory prompts. It must never edit
+ * the service working directory or approve tool calls.
+ */
+
+import { spawn } from "child_process";
+import {
+  clampAvailabilityTimeoutMs,
+  shouldCacheAvailabilityFailure
+} from "./llm/util/availability-timeout.js";
+
+let _agyCLICached = null;
+
+export async function _rawIsAgyCLIAvailable(timeoutMs = null) {
+  if (_agyCLICached !== null) return _agyCLICached;
+
+  const availabilityTimeoutMs = clampAvailabilityTimeoutMs(timeoutMs);
+  try {
+    const { execSync } = await import("child_process");
+    execSync("which agy", { stdio: "ignore", timeout: availabilityTimeoutMs });
+    _agyCLICached = true;
+  } catch {
+    if (shouldCacheAvailabilityFailure(availabilityTimeoutMs)) {
+      _agyCLICached = false;
+    }
+    return false;
+  }
+
+  return _agyCLICached;
+}
+
+export async function isAgyCLIAvailable() {
+  const { isLlmAvailable } = await import("./llm/index.js");
+  return isLlmAvailable();
+}
+
+/**
+ * Builds a non-interactive, read-only Antigravity invocation.
+ *
+ * @param {string} prompt
+ * @param {{model?: string}} [options]
+ * @returns {string[]}
+ */
+export function buildAgyArgs(prompt, options = {}) {
+  const args = [
+    "--print",
+    "--output-format", "text",
+    "--mode", "plan",
+    "--sandbox"
+  ];
+
+  if (options.model) args.push("--model", options.model);
+  args.push(prompt);
+  return args;
+}
+
+/**
+ * Runs Antigravity CLI in constrained print mode and returns its final text.
+ *
+ * @param {string} stdinContent
+ * @param {string} prompt
+ * @param {{timeoutMs?: number, model?: string}} [options]
+ * @returns {Promise<string>}
+ */
+export async function runAgyCLI(stdinContent, prompt, options = {}) {
+  const timeoutMs = options.timeoutMs || 120_000;
+  const args      = buildAgyArgs(prompt, options);
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn("agy", args, {
+      env:   { ...process.env, NO_COLOR: "1" },
+      stdio: ["pipe", "pipe", "pipe"]
+    });
+
+    let stdout  = "";
+    let stderr  = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        proc.kill("SIGTERM");
+        reject(new Error(`Antigravity CLI timed out after ${timeoutMs}ms`));
+      }
+    }, timeoutMs);
+
+    proc.stdout.on("data", (data) => { stdout += data.toString(); });
+    proc.stderr.on("data", (data) => { stderr += data.toString(); });
+
+    proc.on("close", (code) => {
+      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
+
+      if (code !== 0) {
+        const detail = stderr.trim().slice(0, 1000);
+        reject(new Error(`Antigravity CLI exited with code ${code}: ${detail}`));
+        return;
+      }
+
+      resolve(stdout.trim());
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timer);
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Antigravity CLI spawn error: ${err.message}`));
+      }
+    });
+
+    if (stdinContent) proc.stdin.write(stdinContent, "utf8");
+    proc.stdin.end();
+  });
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -241,6 +241,7 @@ const DEFAULT_LLM_CONCURRENCY = {
   "ollama"                                                                  : 16,
   "openai|https://token-plan-sgp.xiaomimimo.com/v1|mimo-v2-pro"            : 8,
   "gemini-cli"                                                              : 1,
+  "agy-cli"                                                                 : 1,
   "copilot-cli"                                                             : 1,
   "codex-cli"                                                               : 1,
   "qwen-cli"                                                                : 1,

--- a/lib/llm/providers/AgyCliProvider.js
+++ b/lib/llm/providers/AgyCliProvider.js
@@ -1,0 +1,49 @@
+/**
+ * Google Antigravity CLI provider.
+ *
+ * Antigravity is constrained to print-only plan mode with its sandbox enabled
+ * because AnchorMind uses it only for structured LLM transformations.
+ */
+
+import { LlmProvider }                                  from "../LlmProvider.js";
+import { parseJsonResponse }                             from "../util/parse-json.js";
+import { runAgyCLI, _rawIsAgyCLIAvailable }             from "../../agy.js";
+
+export class AgyCliProvider extends LlmProvider {
+  constructor(config = {}) {
+    super({ ...config, name: "agy-cli" });
+  }
+
+  async isAvailable(timeoutMs = null) {
+    return _rawIsAgyCLIAvailable(timeoutMs);
+  }
+
+  async callText(_prompt, _options = {}) {
+    throw new Error("agy-cli: use callJson (CLI returns parsed JSON)");
+  }
+
+  async callJson(prompt, options = {}) {
+    if (await this.isCircuitOpen()) {
+      throw new Error("agy-cli: circuit breaker open");
+    }
+
+    const finalPrompt = [
+      options.systemPrompt,
+      "Return one valid JSON value only. Do not wrap it in markdown fences. Do not add commentary before or after the JSON.",
+      prompt
+    ].filter(Boolean).join("\n\n");
+
+    try {
+      const raw = await runAgyCLI("", finalPrompt, {
+        timeoutMs: options.timeoutMs ?? this.config.timeoutMs ?? 120_000,
+        model    : options.model ?? this.config.model
+      });
+      const result = parseJsonResponse(raw);
+      await this.recordSuccess();
+      return result;
+    } catch (err) {
+      await this.recordFailure();
+      throw err;
+    }
+  }
+}

--- a/lib/llm/registry.js
+++ b/lib/llm/registry.js
@@ -27,6 +27,7 @@ import { MistralProvider }      from "./providers/MistralProvider.js";
 import { CohereProvider }       from "./providers/CohereProvider.js";
 import { ZaiProvider }          from "./providers/ZaiProvider.js";
 import { GeminiCliProvider }    from "./providers/GeminiCliProvider.js";
+import { AgyCliProvider }       from "./providers/AgyCliProvider.js";
 import { CodexCliProvider }     from "./providers/CodexCliProvider.js";
 import { CopilotCliProvider }   from "./providers/CopilotCliProvider.js";
 import { QwenCliProvider }      from "./providers/QwenCliProvider.js";
@@ -47,6 +48,7 @@ const PROVIDER_CLASSES = {
   "cohere"      : CohereProvider,
   "zai"         : ZaiProvider,
   "gemini-cli"  : GeminiCliProvider,
+  "agy-cli"     : AgyCliProvider,
   "codex-cli"   : CodexCliProvider,
   "copilot-cli" : CopilotCliProvider,
   "qwen-cli"    : QwenCliProvider,
@@ -70,7 +72,7 @@ export function createProvider(config) {
   if (!Cls) return null;
 
   /** CLI provider는 API 키/URL 없이 로컬 바이너리 + 선택 model/timeout만 사용 */
-  if (name === "gemini-cli" || name === "codex-cli" || name === "copilot-cli" || name === "qwen-cli" || name === "opencode-cli") {
+  if (name === "gemini-cli" || name === "agy-cli" || name === "codex-cli" || name === "copilot-cli" || name === "qwen-cli" || name === "opencode-cli") {
     return new Cls({
       model    : typeof config === "object" ? config.model ?? null : null,
       timeoutMs: typeof config === "object" ? config.timeoutMs ?? null : null,

--- a/tests/unit/agy-cli-args.test.js
+++ b/tests/unit/agy-cli-args.test.js
@@ -1,0 +1,27 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildAgyArgs } from "../../lib/agy.js";
+
+describe("buildAgyArgs", () => {
+  it("print-only, plan, sandbox flags와 model을 항상 포함한다", () => {
+    assert.deepEqual(
+      buildAgyArgs("return json", { model: "gemini-3.1-pro" }),
+      [
+        "--print",
+        "--output-format", "text",
+        "--mode", "plan",
+        "--sandbox",
+        "--model", "gemini-3.1-pro",
+        "return json"
+      ]
+    );
+  });
+
+  it("model이 없으면 Antigravity CLI 기본 모델을 사용한다", () => {
+    assert.deepEqual(
+      buildAgyArgs("return json"),
+      ["--print", "--output-format", "text", "--mode", "plan", "--sandbox", "return json"]
+    );
+  });
+});

--- a/tests/unit/agy-cli-args.test.js
+++ b/tests/unit/agy-cli-args.test.js
@@ -8,11 +8,11 @@ describe("buildAgyArgs", () => {
     assert.deepEqual(
       buildAgyArgs("return json", { model: "gemini-3.1-pro" }),
       [
-        "--print",
         "--output-format", "text",
         "--mode", "plan",
         "--sandbox",
         "--model", "gemini-3.1-pro",
+        "--print",
         "return json"
       ]
     );
@@ -21,7 +21,7 @@ describe("buildAgyArgs", () => {
   it("model이 없으면 Antigravity CLI 기본 모델을 사용한다", () => {
     assert.deepEqual(
       buildAgyArgs("return json"),
-      ["--print", "--output-format", "text", "--mode", "plan", "--sandbox", "return json"]
+      ["--output-format", "text", "--mode", "plan", "--sandbox", "--print", "return json"]
     );
   });
 });

--- a/tests/unit/agy-cli-provider.test.js
+++ b/tests/unit/agy-cli-provider.test.js
@@ -1,0 +1,105 @@
+/**
+ * Unit tests: AgyCliProvider
+ *
+ * No real agy invocation. The CLI wrapper is mocked at module level.
+ */
+
+import { after, beforeEach, describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import { teardownTestResources } from "../_lifecycle.js";
+
+const mockRunAgyCLI   = mock.fn();
+const mockRawIsAgyCli = mock.fn();
+
+mock.module("../../lib/agy.js", {
+  namedExports: {
+    runAgyCLI            : (...args) => mockRunAgyCLI(...args),
+    _rawIsAgyCLIAvailable: (...args) => mockRawIsAgyCli(...args)
+  }
+});
+
+const { AgyCliProvider } = await import("../../lib/llm/providers/AgyCliProvider.js");
+const { createProvider, listProviderNames } = await import("../../lib/llm/registry.js");
+const { getConcurrencyLimit } = await import("../../lib/config.js");
+
+after(async () => { await teardownTestResources(); });
+
+describe("AgyCliProvider", () => {
+  beforeEach(() => {
+    mockRunAgyCLI.mock.resetCalls();
+    mockRawIsAgyCli.mock.resetCalls();
+  });
+
+  it("isAvailable: raw helper 결과를 그대로 반환한다", async () => {
+    mockRawIsAgyCli.mock.mockImplementationOnce(async () => true);
+    const provider = new AgyCliProvider();
+    assert.equal(await provider.isAvailable(), true);
+  });
+
+  it("callText: JSON 전용 provider이므로 use callJson 에러를 던진다", async () => {
+    const provider = new AgyCliProvider();
+    await assert.rejects(() => provider.callText("hello"), /use callJson/);
+  });
+
+  it("callJson: systemPrompt, model, timeout을 constrained CLI helper로 전달한다", async () => {
+    mockRunAgyCLI.mock.mockImplementationOnce(async (stdinContent, prompt, options) => {
+      assert.equal(stdinContent, "");
+      assert.ok(prompt.includes("system rules"));
+      assert.ok(prompt.includes("Return one valid JSON value only."));
+      assert.ok(prompt.includes("user payload"));
+      assert.equal(options.model, "gemini-3.1-pro");
+      assert.equal(options.timeoutMs, 3456);
+      return "{\"ok\":true,\"source\":\"agy-cli\"}";
+    });
+
+    const provider = new AgyCliProvider({ model: "default-model" });
+    const result = await provider.callJson("user payload", {
+      systemPrompt: "system rules",
+      model       : "gemini-3.1-pro",
+      timeoutMs   : 3456
+    });
+
+    assert.deepEqual(result, { ok: true, source: "agy-cli" });
+  });
+
+  it("callJson: provider config의 model과 timeout을 기본값으로 사용한다", async () => {
+    mockRunAgyCLI.mock.mockImplementationOnce(async (_stdinContent, _prompt, options) => {
+      assert.equal(options.model, "gemini-3.1-pro");
+      assert.equal(options.timeoutMs, 2222);
+      return "{\"ok\":true}";
+    });
+
+    const provider = new AgyCliProvider({ model: "gemini-3.1-pro", timeoutMs: 2222 });
+    assert.deepEqual(await provider.callJson("user payload"), { ok: true });
+  });
+
+  it("callJson: circuit breaker open 상태면 helper 호출 없이 에러를 던진다", async () => {
+    const provider = new AgyCliProvider();
+    provider.isCircuitOpen = async () => true;
+
+    await assert.rejects(() => provider.callJson("user payload"), /circuit breaker open/);
+    assert.equal(mockRunAgyCLI.mock.callCount(), 0);
+  });
+});
+
+describe("agy-cli registry wiring", () => {
+  it("listProviderNames: agy-cli를 노출한다", () => {
+    assert.ok(listProviderNames().includes("agy-cli"));
+  });
+
+  it("createProvider: agy-cli config로 provider 인스턴스를 생성한다", () => {
+    const provider = createProvider({
+      provider : "agy-cli",
+      model    : "gemini-3.1-pro",
+      timeoutMs: 2222
+    });
+
+    assert.equal(provider?.name, "agy-cli");
+    assert.equal(provider?.config?.model, "gemini-3.1-pro");
+    assert.equal(provider?.config?.timeoutMs, 2222);
+  });
+
+  it("getConcurrencyLimit: agy-cli 기본 동시성은 다른 로컬 CLI처럼 1이다", () => {
+    assert.equal(getConcurrencyLimit("agy-cli||", "agy-cli"), 1);
+  });
+});


### PR DESCRIPTION
## 목표
Google Antigravity CLI(`agy`)를 AnchorMind의 LLM provider fallback chain에 추가해, Gemini CLI 인증 경로와 독립적으로 구조화된 내부 LLM 작업을 실행할 수 있게 합니다.

## 쉬운 설명
서버가 `agy`를 호출해 JSON만 반환받도록 연결합니다. 파일 수정이나 권한 승인을 수행하지 않는 plan/sandbox 모드로만 실행합니다. 운영자는 `LLM_PRIMARY=agy-cli`와 `LLM_FALLBACKS` 설정만으로 모델과 fallback 순서를 정할 수 있습니다.

## 개선되는 것
### Fix 1: Antigravity CLI provider 추가
`agy-cli` registry 항목과 provider를 추가했습니다. `model`과 `timeoutMs`가 실제 CLI 실행까지 전달되며, circuit breaker와 기존 fallback chain을 그대로 사용합니다.

### Fix 2: 안전한 CLI 실행 계약
`--output-format text --mode plan --sandbox [--model MODEL] --print PROMPT` 순서로 실행합니다. `--print` 뒤의 토큰을 prompt로 해석하는 CLI 특성에 맞춰 인자 순서도 테스트로 고정했습니다.

### Fix 3: 운영 설정 문서화
한국어·영문 설정 문서에 `agy-cli` 사용법과 macOS launchd에서 `~/.local/bin`을 PATH에 명시해야 하는 조건을 추가했습니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| Antigravity CLI 사용 | provider registry에 없어 선택 불가 | `LLM_PRIMARY=agy-cli` 또는 fallback으로 선택 가능 |
| 모델 지정 | 전달 경로 없음 | `model`을 `agy --model`에 전달 |
| 비대화형 실행 | 호출 규약 없음 | print-only, plan, sandbox 고정 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| `agy` 미설치 또는 미인증 | availability 검사에서 chain 제외 | 다음 fallback으로 진행 |
| CLI 응답이 JSON이 아님 | JSON 파싱 실패 후 circuit breaker 기록 | 다음 provider를 시도 |
| launchd 환경 | shell profile을 읽지 않음 | `PATH`에 `~/.local/bin` 명시 필요 |

## 해결한 내용
- `lib/agy.js`: shell 없이 `spawn`으로 CLI 실행, timeout/abort/output 처리
- `AgyCliProvider`: JSON 전용 provider 구현 및 fallback-chain 연결
- registry/config: provider 등록과 CLI concurrency 기본값 추가
- tests: 인자 순서와 provider 동작 10개 회귀 테스트 추가
- docs: 환경변수와 운영 경로 문서화

## 검증
- `node --experimental-test-module-mocks --test tests/unit/agy-cli-args.test.js tests/unit/agy-cli-provider.test.js` - 10 passed
- `npm run lint` - 0 errors, 기존 warnings 127건
- `npm run lint:migrations` - passed
- 실제 `agy --model gemini-3.1-pro-high` 호출 - `{"ok":true,"provider":"agy-cli"}` 응답
- GitHub Unit Tests - passed
- GitHub E2E Tests는 `tests/e2e/group-key-isolation.test.js` fixture가 `api_keys`에 없는 key_id를 삽입하는 기존 foreign-key 오류로 실패했습니다. upstream main의 2026-07-27 run `30270455831`에서도 동일한 6개 실패가 재현되며, 이 PR은 관련 테스트·마이그레이션·memory module을 변경하지 않습니다.