### PR TITLE
fix(e2e): group-key-isolation 시드 키 선삽입 및 재실행 정리

### DIFF
--- a/lib/memory/memory-schema.sql
+++ b/lib/memory/memory-schema.sql
@@ -36,8 +36,11 @@ CREATE TABLE IF NOT EXISTS agent_memory.fragments (
     embedding        vector(1536)
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_frag_hash
-    ON agent_memory.fragments(content_hash);
+-- content_hash 유일성은 migration-031이 정의한다.
+-- key_id(migration-004)에 의존하는 partial unique index 2종
+-- (uq_frag_hash_master / uq_frag_hash_per_key)이므로 이 파일에서는 만들지 않는다.
+-- 여기서 전역 unique index를 만들면 migration-031 적용 이후 이 파일을 다시 실행할 때
+-- 키별 유일성이 전역 유일성으로 되돌아간다.
 CREATE INDEX IF NOT EXISTS idx_frag_topic
     ON agent_memory.fragments(topic);
 CREATE INDEX IF NOT EXISTS idx_frag_type

--- a/tests/e2e/group-key-isolation.test.js
+++ b/tests/e2e/group-key-isolation.test.js
@@ -32,18 +32,63 @@ before(async () => {
     await getPrimaryPool().query("SELECT 1");
     /** fragments 테이블 존재 여부도 확인 */
     await getPrimaryPool().query("SELECT 1 FROM agent_memory.fragments LIMIT 1");
+    await seedTestApiKeys();
   } catch {
     dbOk = false;
     console.warn("[e2e/group-key-isolation] DB unreachable or schema missing — all tests skipped");
   }
 });
 
+/**
+ * 테스트용 API 키 3건을 api_keys에 선삽입한다.
+ *
+ * fragments.key_id는 api_keys(id)를 참조하므로(fragments_key_id_fkey),
+ * 존재하지 않는 key_id로 파편을 저장하면 외래키 위반으로 실패한다.
+ * 재실행 시 중복 삽입되지 않도록 id 충돌은 무시한다.
+ *
+ * @returns {Promise<void>}
+ */
+async function seedTestApiKeys() {
+  await getPrimaryPool().query(
+    `INSERT INTO agent_memory.api_keys (id, name, key_hash, key_prefix)
+     SELECT k.id, k.name, k.key_hash, k.key_prefix
+       FROM unnest($1::text[], $2::text[], $3::text[], $4::text[])
+            AS k(id, name, key_hash, key_prefix)
+     ON CONFLICT (id) DO NOTHING`,
+    [
+      [KEY_A, KEY_B, KEY_C],
+      ["keyiso-test-a", "keyiso-test-b", "keyiso-test-c"],
+      ["keyiso-test-hash-a", "keyiso-test-hash-b", "keyiso-test-hash-c"],
+      ["keyiso-a", "keyiso-b", "keyiso-c"]
+    ]
+  );
+}
+
 after(async () => {
   if (!dbOk) return;
   try {
+    /**
+     * 시드 파편을 만료(valid_to)만 시키면 remember의 동일 content 재사용 경로가
+     * 다음 실행에서 만료된 파편 id를 그대로 반환하여 테스트가 실패한다.
+     * 재실행 가능성을 보장하려면 물리 삭제해야 한다.
+     * fragment_links / fragment_versions / fragment_claims / fragment_evidence는
+     * ON DELETE CASCADE이므로 함께 정리된다.
+     */
     await getPrimaryPool().query(
-      "UPDATE agent_memory.fragments SET valid_to = now() WHERE topic = $1 OR key_id = ANY($2::text[])",
+      `UPDATE agent_memory.fragments SET superseded_by = NULL
+        WHERE superseded_by IN (
+          SELECT id FROM agent_memory.fragments
+           WHERE topic = $1 OR key_id = ANY($2::text[])
+        )`,
       [TOPIC, [KEY_A, KEY_B, KEY_C]]
+    );
+    await getPrimaryPool().query(
+      "DELETE FROM agent_memory.fragments WHERE topic = $1 OR key_id = ANY($2::text[])",
+      [TOPIC, [KEY_A, KEY_B, KEY_C]]
+    );
+    await getPrimaryPool().query(
+      "DELETE FROM agent_memory.api_keys WHERE id = ANY($1::text[])",
+      [[KEY_A, KEY_B, KEY_C]]
     );
   } catch (err) {
     console.warn("[e2e/group-key-isolation] teardown 실패:", err.message);


### PR DESCRIPTION
## 변경

- `tests/e2e/group-key-isolation.test.js`: `before`에서 테스트 API 키 3건을 `api_keys`에 선삽입. `fragments.key_id`가 `api_keys(id)`를 참조하므로 미존재 key_id로 저장하면 외래키 위반이 발생한다.
- 같은 파일 `after`: 시드 파편을 물리 삭제. 만료 처리만 하면 동일 content 재사용 경로가 다음 실행에서 만료된 파편 id를 반환한다.
- `lib/memory/memory-schema.sql`: `content_hash` 전역 unique index 생성 제거. 유일성은 migration-031의 `uq_frag_hash_master` / `uq_frag_hash_per_key`가 정의한다. `tests/e2e/core-flow.test.js`가 setup에서 이 파일을 재적용하므로 전역 index가 되살아나 키별 유일성이 무력화되고 있었다.

## 검증

CI와 동일한 절차(`CREATE EXTENSION vector` → `memory-schema.sql` → `npm run migrate`)로 초기화한 신규 DB에서 측정.

| 항목 | 결과 |
|-|-|
| `npm run test:e2e` 1회차 | 17 pass / 0 fail |
| `npm run test:e2e` 2회차(동일 DB 재실행) | 17 pass / 0 fail |
| `npm test` | 2268 pass / 0 fail |
| `npm run lint` | 0 errors |
| `npm run lint:migrations` | passed |
| 적용 후 hash 인덱스 | `uq_frag_hash_master`, `uq_frag_hash_per_key` 2종만 존재 |

변경 전 main 기준 E2E는 6건 실패(`fragments_key_id_fkey`)였다.