### PR TITLE
fix(consolidate): split 자식 파편 키워드 생성

### DIFF
--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -193,6 +193,7 @@ Grafana 알림 권장 임계값: `memento_quota_used_total / memento_quota_limit
 | `scripts/cleanup-noise.js` | 초단문·빈 세션 요약·NLI 재귀 쓰레기 파편 탐지·삭제 | recall 품질 저하 또는 context 토큰 예산 오염 시 | 조건부, 필요 시 월 1회 |
 | `scripts/post-migrate-flexible-embedding-dims.js` | fragments + morpheme_dict 임베딩 컬럼 차원 동시 조정 | EMBEDDING_DIMENSIONS 변경 또는 provider 전환 시 | 조건부 1회 |
 | `scripts/backfill-claims.js` | 기존 코퍼스에 ClaimExtractor 소급 실행 | Shadow mode(MEMENTO_SYMBOLIC_SHADOW=true) 활성화 전 | 일회성 |
+| `scripts/backfill-split-keywords.js` | keywords가 빈 split 자식 파편에 키워드 소급 생성 | 5.3.1 이하에서 생성된 split 자식이 키워드 검색에 잡히지 않을 때 | 일회성 |
 | `scripts/benchmark-hot-path.js` | remember/recall/link/reflect 4개 hot path p50/p95/p99 측정 | Symbolic Memory feature flag 전환 전후 회귀 기준선 확보 | 조건부 |
 | `scripts/run-e2e-tests.sh` | Docker 기반 E2E 테스트 실행 | CI/CD 파이프라인 또는 대규모 리팩터링 후 회귀 검증 | CI마다 또는 릴리즈 전 |
 | `scripts/smoke-test-symbolic.sh` | Symbolic Memory end-to-end smoke 검증 | MEMENTO_SYMBOLIC_* 플래그 전환 후 | 조건부 |
@@ -227,6 +228,35 @@ DATABASE_URL=postgresql://... node scripts/backfill-embeddings.js
 ### 권장 빈도
 
 `EMBEDDING_PROVIDER` 변경 시 1회. 임베딩 API 장애 복구 후 누락 파편이 있을 경우 조건부 실행.
+
+---
+
+## backfill-split-keywords
+
+### 목적
+
+`source LIKE 'split:%'`이면서 `keywords`가 비어 있는 파편에 본문 기반 키워드를 소급 생성한다. 키워드가 빈 파편은 배열 교집합(`keywords && $1`)을 사용하는 검색 경로에서 조회되지 않는다.
+
+추출은 정상 저장 경로와 동일하게 `FragmentFactory.extractKeywords(content)`를 사용한다. 추출 결과가 비면 해당 파편은 건너뛰며 빈 배열로 덮어쓰지 않는다.
+
+### 선행 조건
+
+- `DATABASE_URL` 환경변수 설정
+- 기본 실행은 dryRun이며 대상 건수와 샘플만 출력한다. 실제 반영은 `--execute` 필수
+
+### 실행 명령
+
+```
+node scripts/backfill-split-keywords.js            # 미리보기
+node scripts/backfill-split-keywords.js --execute  # 실제 반영
+```
+
+### 대상 확인 질의
+
+```sql
+SELECT count(*) FROM agent_memory.fragments
+ WHERE source LIKE 'split:%' AND coalesce(cardinality(keywords), 0) = 0;
+```
 
 ---
 

--- a/lib/memory/consolidate/ConsolidatorGC.js
+++ b/lib/memory/consolidate/ConsolidatorGC.js
@@ -10,6 +10,7 @@ import { MEMORY_CONFIG } from "../../../config/memory.js";
 import { geminiCLIJson, isGeminiCLIAvailable } from "../../gemini.js";
 import { logInfo, logWarn } from "../../logger.js";
 import { isAcceptableSplitChild, clampChildImportance } from "./split-gate.js";
+import { FragmentFactory } from "../write/FragmentFactory.js";
 import { resolveSplitChainConfig } from "../../config.js";
 import { recordSplitSkip } from "./split-metrics.js";
 import { feedbackFactor } from "./feedbackFactor.js";
@@ -48,6 +49,8 @@ export class ConsolidatorGC {
    */
   constructor(store) {
     this.store = store;
+    /** split 자식 키워드 추출용. 정상 저장 경로(FragmentFactory)와 동일 규칙을 쓴다. */
+    this.factory = new FragmentFactory();
   }
 
   /**
@@ -446,7 +449,7 @@ export class ConsolidatorGC {
         topic     : frag.topic,
         type      : frag.type,
         importance: childImportance,
-        keywords  : [],
+        keywords  : this.factory.extractKeywords(text),
         source    : `split:${frag.id}`,
         linked_to : [],
         ttl_tier  : "warm",

--- a/scripts/backfill-split-keywords.js
+++ b/scripts/backfill-split-keywords.js
@@ -1,0 +1,86 @@
+/**
+ * backfill-split-keywords.js — split 자식 파편 키워드 소급 생성
+ *
+ * 작성자: 최진호
+ * 작성일: 2026-08-02
+ *
+ * 대상: source LIKE 'split:%' AND keywords가 비어 있는 파편.
+ * 규칙: 정상 저장 경로와 동일하게 FragmentFactory.extractKeywords(content) 결과를
+ *       채운다. 추출 결과가 비면 해당 파편은 건너뛴다(빈 배열로 덮어쓰지 않음).
+ *       기본은 dryRun(변경 없음). 실제 UPDATE는 --execute 필수.
+ *
+ * 사용:
+ *   node scripts/backfill-split-keywords.js            # 미리보기
+ *   node scripts/backfill-split-keywords.js --execute  # 실제 반영
+ */
+
+import { getPrimaryPool }  from "../lib/tools/db.js";
+import { FragmentFactory } from "../lib/memory/write/FragmentFactory.js";
+
+const SCHEMA    = "agent_memory";
+const BATCH_SIZE = 500;
+
+const args    = process.argv.slice(2);
+const execute = args.includes("--execute");
+
+async function main() {
+  const pool = getPrimaryPool();
+  if (!pool) {
+    console.error("DB pool unavailable");
+    process.exit(1);
+  }
+
+  const factory = new FragmentFactory();
+
+  const { rows } = await pool.query(
+    `SELECT id, content
+       FROM ${SCHEMA}.fragments
+      WHERE source LIKE 'split:%'
+        AND coalesce(cardinality(keywords), 0) = 0`
+  );
+
+  const planned = [];
+  let empty     = 0;
+
+  for (const f of rows) {
+    const keywords = factory.extractKeywords(String(f.content ?? ""));
+    if (!keywords.length) {
+      empty++;
+      continue;
+    }
+    planned.push({ id: f.id, keywords, snippet: String(f.content ?? "").slice(0, 50) });
+  }
+
+  console.log(`대상 ${rows.length}건 중 추출 성공 ${planned.length} / 추출 불가 ${empty}`);
+  for (const p of planned.slice(0, 5)) {
+    console.log(`  - ${p.id} :: [${p.keywords.join(", ")}] :: ${p.snippet}`);
+  }
+
+  if (!execute) {
+    console.log("\ndryRun — 변경 없음. 실제 반영은 --execute.");
+    await pool.end?.();
+    return;
+  }
+
+  /** 파편마다 키워드 배열이 다르므로 행 단위로 갱신한다. 진행 상황은 배치 경계에서 출력. */
+  let updated = 0;
+  for (const [i, p] of planned.entries()) {
+    const { rowCount } = await pool.query(
+      `UPDATE ${SCHEMA}.fragments
+          SET keywords = $2::text[]
+        WHERE id = $1
+          AND coalesce(cardinality(keywords), 0) = 0`,
+      [p.id, p.keywords]
+    );
+    updated += rowCount;
+    if ((i + 1) % BATCH_SIZE === 0) console.log(`  진행 ${i + 1}/${planned.length}`);
+  }
+
+  console.log(`\nUPDATE 완료: ${updated}건`);
+  await pool.end?.();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/unit/consolidator-split-child-keywords.test.js
+++ b/tests/unit/consolidator-split-child-keywords.test.js
@@ -1,0 +1,131 @@
+/**
+ * Unit tests: split 자식 파편이 본문 기반 keywords와 함께 저장되는지 검증한다.
+ *
+ * 빈 keywords로 저장되면 keywords 배열 교집합(&&)을 쓰는 검색 경로에서
+ * 영구히 조회되지 않으므로, 정상 저장 경로(FragmentFactory)와 동일한
+ * 추출 규칙이 적용되어야 한다.
+ */
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+let llmReturn = [];
+mock.module("../../lib/gemini.js", {
+  namedExports: {
+    isGeminiCLIAvailable: async () => true,
+    geminiCLIJson       : async () => llmReturn
+  }
+});
+
+mock.module("../../lib/tools/db.js", {
+  exports: {
+    getPrimaryPool      : () => null,
+    queryWithAgentVector: async () => ({ rows: [], rowCount: 0 })
+  }
+});
+
+mock.module("../../lib/config.js", {
+  namedExports: {
+    resolveSplitChainConfig: () => null,
+    LLM_PRIMARY            : "gemini-cli",
+    LLM_FALLBACKS          : [],
+    /** FragmentWriter가 요구 — 이 테스트는 DB 경로를 타지 않으므로 값은 무의미 */
+    buildSearchPath        : () => "agent_memory, public"
+  }
+});
+
+/** FragmentFactory → FragmentWriter → embedding.js 경로가 실제 config를 요구하므로 최소 대체 */
+mock.module("../../lib/tools/embedding.js", {
+  namedExports: { computeContentHash: (text) => `hash-${String(text).length}` }
+});
+
+mock.module("../../lib/logger.js", {
+  exports: {
+    logInfo        : () => {},
+    logWarn        : () => {},
+    logError       : () => {},
+    logDebug       : () => {},
+    REDACT_PATTERNS: [],
+    redactString   : (v) => v
+  }
+});
+
+mock.module("../../lib/memory/consolidate/split-metrics.js", {
+  namedExports: {
+    recordSplitSkip  : () => {},
+    splitSkippedTotal: { inc: () => {} }
+  }
+});
+
+mock.module("../../config/memory.js", {
+  exports: {
+    MEMORY_CONFIG: {
+      fragmentSplit: {
+        lengthThreshold    : 300,
+        batchSize          : 10,
+        minItems           : 2,
+        maxItems           : 8,
+        timeoutMs          : 30_000,
+        excludeMetaTopics  : [],
+        failureBackoffHours: 24
+      }
+    }
+  }
+});
+
+const { ConsolidatorGC } = await import("../../lib/memory/consolidate/ConsolidatorGC.js");
+
+function makeStubs() {
+  const inserted = [];
+  const store = {
+    insert    : async (f) => { inserted.push(f); return f.id; },
+    delete    : async () => true,
+    createLink: async () => {}
+  };
+  const pool = {
+    query: async (sql) => {
+      if (/SELECT id, content/.test(sql)) {
+        return {
+          rows: [{
+            id: "parent-1", content: "z".repeat(400), topic: "infra",
+            type: "fact", importance: 0.9, agent_id: "default", key_id: null
+          }],
+          rowCount: 1
+        };
+      }
+      return { rowCount: 1, rows: [] };
+    }
+  };
+  return { store, pool, inserted };
+}
+
+describe("split 자식 keywords 생성", () => {
+  it("자식마다 본문에서 추출한 keywords를 채워 저장한다", async () => {
+    llmReturn = [
+      "nginx 업스트림 커넥션 풀이 고갈되어 502 응답률이 상승했다",
+      "worker_connections 값을 8192로 올린 뒤 복구가 완료되었다"
+    ];
+    const { store, pool, inserted } = makeStubs();
+    await new ConsolidatorGC(store).splitLongFragments({ pool });
+
+    assert.equal(inserted.length, 2);
+    for (const child of inserted) {
+      assert.ok(Array.isArray(child.keywords), "keywords는 배열이어야 한다");
+      assert.ok(child.keywords.length > 0, `빈 keywords로 저장됨: ${child.content}`);
+    }
+  });
+
+  it("추출된 keywords가 자식 본문의 고유 토큰을 반영한다", async () => {
+    llmReturn = [
+      "nginx 업스트림 커넥션 풀이 고갈되어 502 응답률이 상승했다",
+      "worker_connections 값을 8192로 올린 뒤 복구가 완료되었다"
+    ];
+    const { store, pool, inserted } = makeStubs();
+    await new ConsolidatorGC(store).splitLongFragments({ pool });
+
+    const first  = inserted[0].keywords.join(" ");
+    const second = inserted[1].keywords.join(" ");
+    assert.ok(first.includes("nginx"), `첫 자식 keywords에 nginx 없음: ${first}`);
+    assert.ok(second.includes("worker_connections"), `둘째 자식 keywords에 식별자 없음: ${second}`);
+    assert.notDeepEqual(inserted[0].keywords, inserted[1].keywords, "자식마다 본문 기준으로 달라야 한다");
+  });
+});

--- a/tests/unit/consolidator-split-child-quality.test.js
+++ b/tests/unit/consolidator-split-child-quality.test.js
@@ -32,8 +32,14 @@ mock.module("../../lib/config.js", {
   namedExports: {
     resolveSplitChainConfig: () => [{ provider: "xai" }],
     LLM_PRIMARY            : "gemini-cli",
-    LLM_FALLBACKS          : []
+    LLM_FALLBACKS          : [],
+    /** ConsolidatorGC가 키워드 추출을 위해 write 계층을 로드하므로 필요 */
+    buildSearchPath        : () => "agent_memory, public"
   }
+});
+
+mock.module("../../lib/tools/embedding.js", {
+  namedExports: { computeContentHash: (text) => `hash-${String(text).length}` }
 });
 
 mock.module("../../lib/logger.js", {

--- a/tests/unit/consolidator-split-partial-yield.test.js
+++ b/tests/unit/consolidator-split-partial-yield.test.js
@@ -21,7 +21,17 @@ mock.module("../../lib/tools/db.js", {
 });
 
 mock.module("../../lib/config.js", {
-  namedExports: { resolveSplitChainConfig: () => null, LLM_PRIMARY: "gemini-cli", LLM_FALLBACKS: [] }
+  namedExports: {
+    resolveSplitChainConfig: () => null,
+    LLM_PRIMARY            : "gemini-cli",
+    LLM_FALLBACKS          : [],
+    /** ConsolidatorGC가 키워드 추출을 위해 write 계층을 로드하므로 필요 */
+    buildSearchPath        : () => "agent_memory, public"
+  }
+});
+
+mock.module("../../lib/tools/embedding.js", {
+  namedExports: { computeContentHash: (text) => `hash-${String(text).length}` }
 });
 
 mock.module("../../lib/logger.js", {


### PR DESCRIPTION
이슈 #32 대응.

## 변경

- `lib/memory/consolidate/ConsolidatorGC.js`: `_commitSplit`이 자식 파편을 `keywords: []`로 저장하던 것을 `FragmentFactory.extractKeywords(text)` 결과로 채운다. 팩토리는 생성자에서 1회 생성한다. `SpreadingActivation.js:63-65`, `FragmentIndex.js:76`이 쓰는 재사용 패턴과 동일하다.
- `scripts/backfill-split-keywords.js`: 기존 파편 소급 처리. `source LIKE 'split:%'`이면서 keywords가 빈 파편만 대상이며 dryRun 기본, `--execute`로만 반영한다. 추출 결과가 비면 건너뛴다.
- `tests/unit/consolidator-split-child-keywords.test.js`: 신규.
- `tests/unit/consolidator-split-partial-yield.test.js`, `tests/unit/consolidator-split-child-quality.test.js`: ConsolidatorGC가 write 계층을 로드하게 되어 `lib/config.js` 목에 `buildSearchPath`와 `lib/tools/embedding.js` 목을 추가했다.

## 근거

빈 keywords는 배열 교집합 연산(`f.keywords && $1::text[]`, `SpreadingActivation.js:79`)에서 구조적으로 매치될 수 없다. 실제 DB에서 재현한 결과 split 자식은 키워드 검색에 한 건도 잡히지 않았고, 변경 후 동일 검사에서 정상 매치됐다.

## 검증

격리 DB에서 측정.

| 항목 | 변경 전 | 변경 후 |
|-|-|-|
| split 자식 keywords 개수 | 0, 0, 0 | 5, 5, 5 |
| 키워드 검색 매치에 자식 포함 | false | true |
| `npm test` | 2277 pass | 2282 pass / 0 fail |
| `npm run test:e2e` | 17 pass | 17 pass / 0 fail |
| `npm run lint` | 0 errors | 0 errors |

백필 스크립트는 dryRun에서 대상 2건을 보고하고 DB를 바꾸지 않았으며, `--execute`에서 해당 2건만 갱신하고 키워드가 이미 있는 파편은 건드리지 않았다.