### PR TITLE
fix(gc): 분할 자식이 남은 원본 파편 보존

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -806,6 +806,8 @@ recall에 `includeLinks: true`(기본값)가 설정되어 있으면 결과 파�
 
 `isAnchor: true`로 표시된 파편은 어느 계층에 있든 MemoryConsolidator의 감쇠 및 삭제 대상에서 영구적으로 제외된다. 중요도가 0.1이더라도 삭제되지 않는다. 절대 잃어서는 안 되는 지식에 사용한다.
 
+`splitLongFragments`로 분할된 원본은 `source = 'split:{원본 id}'`인 자식이 하나라도 남아 있는 동안 만료 삭제 대상에서 제외된다. 분할은 원본을 `valid_to` 설정과 함께 importance 하향·`cold` 강등 처리하므로, 이 보호가 없으면 원본이 utility 기준으로 물리 삭제되어 자식만 남는다. 자식이 모두 정리된 뒤에는 일반 GC 규칙이 그대로 적용된다.
+
 stale 기준(일): procedure=30, fact=60, decision=90, default=60. `config/memory.js`의 `MEMORY_CONFIG.staleThresholds`에서 조정한다.
 
 ---

--- a/lib/memory/write/FragmentWriter.js
+++ b/lib/memory/write/FragmentWriter.js
@@ -750,6 +750,13 @@ export class FragmentWriter {
          WHERE ttl_tier NOT IN ('permanent')
            AND is_anchor = FALSE
            AND created_at < NOW() - make_interval(days => $1)
+           /** 분할 자식이 남아 있는 원본은 대조군으로 보존한다.
+            *  split은 원본을 valid_to + importance 하향 + cold로 바꾸므로
+            *  이 조건이 없으면 utility 분기에서 원본이 물리 삭제된다. */
+           AND NOT EXISTS (
+             SELECT 1 FROM ${SCHEMA}.fragments split_child
+             WHERE split_child.source = 'split:' || fragments.id
+           )
            AND (
              (utility_score < $2
               AND (accessed_at IS NULL OR accessed_at < NOW() - make_interval(days => $3))

--- a/tests/unit/gc-split-parent-guard.test.js
+++ b/tests/unit/gc-split-parent-guard.test.js
@@ -1,0 +1,28 @@
+/**
+ * Unit tests: GC가 분할 자식이 남아 있는 원본 파편을 물리 삭제하지 않는지 검증한다.
+ *
+ * split은 원본을 valid_to + importance 하향 + ttl_tier='cold'로 바꾸는데,
+ * deleteExpired의 utility 분기에는 valid_to 조건도 링크 보호도 없으므로
+ * 원본 보존은 명시적인 자식 존재 검사에 의존한다.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+describe("GC split 원본 보호", () => {
+  test("deleteExpired SQL이 분할 자식 존재 시 원본을 후보에서 제외한다", async () => {
+    const { FragmentWriter } = await import("../../lib/memory/write/FragmentWriter.js");
+    const src = new FragmentWriter().deleteExpired.toString();
+
+    assert.ok(src.includes("NOT EXISTS"), "자식 존재 검사 필수");
+    assert.ok(src.includes("'split:' || fragments.id"), "split 자식 source 상관 조건 필수");
+  });
+
+  test("기존 GC 조건이 함께 유지된다", async () => {
+    const { FragmentWriter } = await import("../../lib/memory/write/FragmentWriter.js");
+    const src = new FragmentWriter().deleteExpired.toString();
+
+    assert.ok(src.includes("is_anchor = FALSE"), "anchor 보호 유지");
+    assert.ok(src.includes("ttl_tier NOT IN ('permanent')"), "permanent 보호 유지");
+    assert.ok(src.includes("type IS NULL"), "NULL type 조건 유지");
+  });
+});


### PR DESCRIPTION
이슈 #33-2 대응.

## 변경

- `lib/memory/write/FragmentWriter.js`: `deleteExpired`의 후보 CTE에 `source = 'split:' || fragments.id`인 자식 존재 검사를 추가해, 자식이 남아 있는 원본을 물리 삭제 대상에서 제외한다. `idx_frag_source`가 있어 상관 서브쿼리가 인덱스를 사용한다.
- `docs/architecture.md`: 보호 규칙과 해제 조건 기술.
- `tests/unit/gc-split-parent-guard.test.js`: 신규.

## 근거

`deleteExpired`의 utility 분기에는 `valid_to` 조건이 없고 링크 보호(`NOT EXISTS ... fragment_links`)는 fact/decision 분기에만 있다. split은 원본을 `valid_to = NOW()`, `importance = GREATEST(0.2, importance * 0.3)`, `ttl_tier = 'cold'`로 바꾸므로 anchor·permanent 보호도 적용되지 않는다. tombstone된 원본은 검색에서 빠져 `accessed_at`이 갱신되지 않으므로 비활성 조건도 자동 충족된다.

격리 DB에서 실측한 도달 시점은 다음과 같다(importance 0.21 기준).

| 원본 나이 | utility_score | 변경 전 물리 삭제 |
|-|-|-|
| 24일 | 0.2000 | 삭제 안 됨 |
| 90일 | 0.1438 | 삭제됨 |
| 180일 | 0.1168 | 삭제됨 |

임계는 약 92일이다. 이슈 보고자의 운영 기간은 24일이므로 보고된 개별 소멸 1건이 이 경로였다고 단정할 수는 없으나, 경로 자체는 실재하며 3개월 이상 운영되는 인스턴스에서 발현된다.

## 검증

| 시나리오 | 결과 |
|-|-|
| 자식이 있는 120일 경과 tombstone 원본 | 잔존 |
| 자식이 없는 120일 경과 tombstone 파편 | 기존대로 삭제 |
| `npm test` | 2280 pass / 0 fail |
| `npm run lint` | 0 errors |

과차단이 없는지 확인하기 위해 자식 없는 대조군을 같은 사이클에서 함께 측정했다.