### PR TITLE
feat(consolidate): 분할 앵커 커버리지 게이트

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -465,6 +465,8 @@ LLM 재작성이 수반되어 파편 내용을 변경할 수 있는 3개 stage�
 
 Phase 1(gate-only)에서 통과 자식 수 < `minItems`이면 DB insert 없이 해당 파편의 `split_attempt_failed_at`을 갱신하고 `memento_consolidate_split_skipped_total{reason="low_yield"}`를 증가시킨다. 분할 성공 시 원본은 `valid_to = NOW()`, `ttl_tier = 'cold'`, `importance = GREATEST(0.2, importance × 0.3)` 처리된다.
 
+앵커 커버리지 검사: 분할은 원문을 자르지 않고 LLM이 다시 쓰므로 명제 하나가 통째로 누락될 수 있다. 자식 저장 직전에 원문의 수치 앵커(날짜·금액·비율·측정값)가 자식 합집합에 모두 남아 있는지 대조하고, 하나라도 빠지면 자식을 저장하지 않고 원본을 그대로 둔다. 이때 `split_attempt_failed_at`을 갱신하고 `memento_consolidate_split_skipped_total{reason="anchor_loss"}`를 증가시킨다. 날짜 `2026-07-15`는 `2026`/`07`/`15`로, 범위 `75~85`는 `75`/`85`로 분해 비교하므로 표기가 바뀌어도 구성 숫자가 남으면 보존으로 판정한다. 자릿수 구분자는 무시하며, 한 자리 숫자와 수치가 전혀 없는 원문은 판정 대상에서 제외한다.
+
 ### SearchParamAdaptor (자동 검색 파라미터 학습)
 
 SearchParamAdaptor는 별도 환경변수 없이 자동으로 동작한다. `config/memory.js`의 `semanticSearch.minSimilarity` 값을 기본값으로 사용하며, 50회 이상 검색 후 key_id x query_type x hour 조합별로 학습된 값으로 대체된다.

--- a/docs/operations/llm-providers.md
+++ b/docs/operations/llm-providers.md
@@ -346,3 +346,4 @@ split skip 건수를 `reason` 라벨별로 측정한다.
 | `llm_error` | LLM 호출/파싱 기타 실패 |
 | `low_yield` | 게이트 통과 자식 수 < `minItems` |
 | `insert_shortfall` | insert 후 자식 수 < `minItems` (롤백됨) |
+| `anchor_loss` | 자식 합집합에 원문의 수치 앵커가 남지 않아 원본 대체 중단 |

--- a/lib/memory/consolidate/ConsolidatorGC.js
+++ b/lib/memory/consolidate/ConsolidatorGC.js
@@ -9,7 +9,7 @@ import { getPrimaryPool, queryWithAgentVector } from "../../tools/db.js";
 import { MEMORY_CONFIG } from "../../../config/memory.js";
 import { geminiCLIJson, isGeminiCLIAvailable } from "../../gemini.js";
 import { logInfo, logWarn } from "../../logger.js";
-import { isAcceptableSplitChild, clampChildImportance } from "./split-gate.js";
+import { isAcceptableSplitChild, clampChildImportance, findMissingAnchors } from "./split-gate.js";
 import { FragmentFactory } from "../write/FragmentFactory.js";
 import { resolveSplitChainConfig } from "../../config.js";
 import { recordSplitSkip } from "./split-metrics.js";
@@ -406,6 +406,17 @@ export class ConsolidatorGC {
       if (accepted.length < minItems) {
         await this._recordSplitOutcome(pool, frag, "low_yield",
           `split skipped for ${frag.id}: only ${accepted.length} clean child(ren) (< ${minItems})`);
+        return false;
+      }
+
+      /** Coverage guard: 자식 합집합이 원문의 수치 앵커를 모두 담지 못하면
+       *  명제가 통째로 누락된 것이므로 원문을 대체하지 않는다. 자식은 아직
+       *  저장 전이라 롤백할 것이 없다. */
+      const missingAnchors = findMissingAnchors(frag.content, accepted.map(a => a.text));
+      if (missingAnchors.length > 0) {
+        await this._recordSplitOutcome(pool, frag, "anchor_loss",
+          `split skipped for ${frag.id}: ${missingAnchors.length} source anchor(s) missing from children ` +
+          `(${missingAnchors.slice(0, 5).join(", ")})`);
         return false;
       }
 

--- a/lib/memory/consolidate/split-gate.js
+++ b/lib/memory/consolidate/split-gate.js
@@ -36,6 +36,53 @@ export function isAcceptableSplitChild(text, parentType) {
   return true;
 }
 
+/** 수치 토큰. 소수점·자릿수 구분자를 포함한 연속 숫자를 하나로 잡는다. */
+const NUMERIC_TOKEN = /\d+(?:[.,]\d+)*/g;
+
+/** 자릿수 구분자만 제거한다. 날짜 하이픈·범위 물결표는 토큰 경계이므로 분리 상태를 유지한다. */
+const normalizeAnchor = (s) => s.replace(/,/g, "");
+
+/**
+ * 원문 보존 검증에 쓸 수치 앵커를 추출한다.
+ *
+ * 날짜·금액·비율·측정값처럼 재작성으로 바뀌기 어려운 토큰만 대상으로 한다.
+ * "2026-07-15"는 2026/07/15로, "75~85"는 75/85로 분리되므로 표현이 바뀌어도
+ * 구성 숫자가 남아 있으면 보존된 것으로 판정한다. 한 자리 숫자는 우연 일치가
+ * 잦아 제외한다.
+ *
+ * @param {string} text
+ * @returns {string[]} 중복 제거된 앵커 목록
+ */
+export function extractNumericAnchors(text) {
+  if (typeof text !== "string") return [];
+
+  const anchors = new Set();
+  for (const token of text.match(NUMERIC_TOKEN) ?? []) {
+    const normalized = normalizeAnchor(token);
+    if (normalized.length >= 2) anchors.add(normalized);
+  }
+  return [...anchors];
+}
+
+/**
+ * 부모 원문의 수치 앵커 중 자식 어디에도 남지 않은 것을 반환한다.
+ *
+ * LLM 분할은 원문을 자르는 것이 아니라 다시 쓰므로 명제 하나가 통째로
+ * 누락될 수 있다. 앵커가 하나도 없는 원문은 이 검사로 판정할 수 없으므로
+ * 빈 배열을 반환한다.
+ *
+ * @param {string}   parentContent
+ * @param {string[]} childTexts
+ * @returns {string[]} 유실된 앵커 목록
+ */
+export function findMissingAnchors(parentContent, childTexts) {
+  const anchors = extractNumericAnchors(parentContent);
+  if (anchors.length === 0) return [];
+
+  const haystack = normalizeAnchor((childTexts ?? []).join(" "));
+  return anchors.filter(anchor => !haystack.includes(anchor));
+}
+
 /**
  * 자식 importance를 부모×0.7 상한으로 클램프한다.
  * fact 타입은 0.4 미만이면 저장 부적합으로 null을 반환한다.

--- a/lib/memory/consolidate/split-metrics.js
+++ b/lib/memory/consolidate/split-metrics.js
@@ -9,6 +9,7 @@
  *   llm_error       — LLM 호출/파싱 기타 실패
  *   low_yield       — 게이트 통과 자식 수 < minItems
  *   insert_shortfall— insert 후 자식 수 < minItems (롤백됨)
+ *   anchor_loss     — 자식 합집합에 원문 수치 앵커가 빠져 원문 대체 중단
  */
 
 import promClient  from "prom-client";
@@ -24,7 +25,7 @@ export const splitSkippedTotal = new promClient.Counter({
 
 /**
  * 분할 skip을 reason 라벨과 함께 1 증가시킨다.
- * @param {"provider_error"|"llm_error"|"low_yield"|"insert_shortfall"} reason
+ * @param {"provider_error"|"llm_error"|"low_yield"|"insert_shortfall"|"anchor_loss"} reason
  */
 export function recordSplitSkip(reason) {
   splitSkippedTotal.inc({ reason });

--- a/tests/unit/consolidator-split-anchor-guard.test.js
+++ b/tests/unit/consolidator-split-anchor-guard.test.js
@@ -1,0 +1,155 @@
+/**
+ * Unit tests: 자식 합집합이 원문 수치 앵커를 잃으면 원본을 대체하지 않는다.
+ *
+ * 자식이 minItems를 넘겨도 명제가 통째로 누락될 수 있으므로,
+ * 이 경우 insert도 tombstone도 하지 않고 원본을 그대로 둔다.
+ */
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+let llmReturn = [];
+mock.module("../../lib/gemini.js", {
+  namedExports: {
+    isGeminiCLIAvailable: async () => true,
+    geminiCLIJson       : async () => llmReturn
+  }
+});
+
+mock.module("../../lib/tools/db.js", {
+  exports: {
+    getPrimaryPool      : () => null,
+    queryWithAgentVector: async () => ({ rows: [], rowCount: 0 })
+  }
+});
+
+mock.module("../../lib/config.js", {
+  namedExports: {
+    resolveSplitChainConfig: () => null,
+    LLM_PRIMARY            : "gemini-cli",
+    LLM_FALLBACKS          : [],
+    buildSearchPath        : () => "agent_memory, public"
+  }
+});
+
+mock.module("../../lib/tools/embedding.js", {
+  namedExports: { computeContentHash: (text) => `hash-${String(text).length}` }
+});
+
+mock.module("../../lib/logger.js", {
+  exports: {
+    logInfo        : () => {},
+    logWarn        : () => {},
+    logError       : () => {},
+    logDebug       : () => {},
+    REDACT_PATTERNS: [],
+    redactString   : (v) => v
+  }
+});
+
+const skipReasons = [];
+mock.module("../../lib/memory/consolidate/split-metrics.js", {
+  namedExports: {
+    recordSplitSkip  : (reason) => { skipReasons.push(reason); },
+    splitSkippedTotal: { inc: () => {} }
+  }
+});
+
+mock.module("../../config/memory.js", {
+  exports: {
+    MEMORY_CONFIG: {
+      fragmentSplit: {
+        lengthThreshold    : 300,
+        batchSize          : 10,
+        minItems           : 2,
+        maxItems           : 8,
+        timeoutMs          : 30_000,
+        excludeMetaTopics  : [],
+        failureBackoffHours: 24
+      }
+    }
+  }
+});
+
+const { ConsolidatorGC } = await import("../../lib/memory/consolidate/ConsolidatorGC.js");
+
+/** 수치 앵커 2026 / 07 / 15 / 75 / 85 / 14 를 담은 원문 */
+const PARENT_CONTENT =
+  "A사는 2026-07-15 서면을 제출하여 대리인 지위를 취득했고 담당 부서는 접수 사실을 통지했다. " +
+  "내부 검토 결과 인용 가능성은 75~85%로 평가되었으며 평가 근거가 함께 정리되었다. " +
+  "증거 목록은 총 14건으로 확정되었고 추가 제출 계획은 없다고 기록되었다. " +
+  "후속 절차와 담당자는 별도 문서에 정리되어 공유되었다.";
+
+function makeStubs() {
+  const inserted = [];
+  let tombstoned = false;
+  let backoffMarked = false;
+
+  const store = {
+    insert    : async (f) => { inserted.push(f); return f.id; },
+    delete    : async () => true,
+    createLink: async () => {}
+  };
+  const pool = {
+    query: async (sql) => {
+      if (/SELECT id, content/.test(sql)) {
+        return {
+          rows: [{
+            id: "parent-1", content: PARENT_CONTENT, topic: "legal",
+            type: "fact", importance: 0.9, agent_id: "default", key_id: null
+          }],
+          rowCount: 1
+        };
+      }
+      if (/split_attempt_failed_at = NOW\(\)/.test(sql)) backoffMarked = true;
+      if (/UPDATE .*fragments/.test(sql) && /valid_to/.test(sql)) tombstoned = true;
+      return { rowCount: 1, rows: [] };
+    }
+  };
+  return { store, pool, inserted, tombstone: () => tombstoned, backoff: () => backoffMarked };
+}
+
+describe("split 앵커 커버리지 가드", () => {
+  it("자식이 원문 앵커를 잃으면 insert도 tombstone도 하지 않는다", async () => {
+    skipReasons.length = 0;
+    /** "14건"에 해당하는 명제가 빠졌다. 나머지 앵커는 보존된다. */
+    llmReturn = [
+      "A사는 2026-07-15 서면을 제출하여 대리인 지위를 취득했다",
+      "내부 검토 결과 인용 가능성은 75~85%로 평가되었다"
+    ];
+    const { store, pool, inserted, tombstone } = makeStubs();
+    const count = await new ConsolidatorGC(store).splitLongFragments({ pool });
+
+    assert.equal(inserted.length, 0, "앵커 유실 시 자식을 저장하지 않는다");
+    assert.equal(tombstone(), false, "원본은 valid_to NULL을 유지한다");
+    assert.equal(count, 0);
+    assert.ok(skipReasons.includes("anchor_loss"), `기록된 reason: ${skipReasons.join(",")}`);
+  });
+
+  it("앵커 유실 시 재시도 backoff를 기록한다", async () => {
+    skipReasons.length = 0;
+    llmReturn = [
+      "A사는 2026-07-15 서면을 제출하여 대리인 지위를 취득했다",
+      "내부 검토 결과 인용 가능성은 75~85%로 평가되었다"
+    ];
+    const { store, pool, backoff } = makeStubs();
+    await new ConsolidatorGC(store).splitLongFragments({ pool });
+
+    assert.equal(backoff(), true, "다음 사이클 즉시 재시도를 막아야 한다");
+  });
+
+  it("모든 앵커가 보존되면 정상 분할한다", async () => {
+    skipReasons.length = 0;
+    llmReturn = [
+      "A사는 2026-07-15 서면을 제출하여 대리인 지위를 취득했다",
+      "내부 검토 결과 인용 가능성은 75~85%로 평가되었다",
+      "증거 목록은 총 14건으로 확정되었다"
+    ];
+    const { store, pool, inserted, tombstone } = makeStubs();
+    const count = await new ConsolidatorGC(store).splitLongFragments({ pool });
+
+    assert.equal(inserted.length, 3);
+    assert.equal(tombstone(), true, "앵커가 보존되면 원본을 대체한다");
+    assert.equal(count, 1);
+    assert.equal(skipReasons.length, 0);
+  });
+});

--- a/tests/unit/split-anchor-coverage.test.js
+++ b/tests/unit/split-anchor-coverage.test.js
@@ -1,0 +1,82 @@
+/**
+ * Unit tests: 분할 자식이 원문의 수치 앵커를 보존하는지 판정하는 순수 함수.
+ *
+ * LLM 분할은 원문을 자르지 않고 다시 쓰므로 명제가 통째로 누락될 수 있다.
+ * 날짜·금액·비율은 재작성으로 값이 바뀌기 어려우므로 보존 판정 기준이 된다.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { extractNumericAnchors, findMissingAnchors } from "../../lib/memory/consolidate/split-gate.js";
+
+describe("extractNumericAnchors", () => {
+  it("날짜를 구성 숫자로 분리한다", () => {
+    assert.deepEqual(extractNumericAnchors("2026-07-15 제출"), ["2026", "07", "15"]);
+  });
+
+  it("자릿수 구분자를 제거하고 범위는 양끝을 각각 남긴다", () => {
+    const anchors = extractNumericAnchors("비용 1,200만 원, 가능성 75~85%");
+    assert.ok(anchors.includes("1200"));
+    assert.ok(anchors.includes("75"));
+    assert.ok(anchors.includes("85"));
+  });
+
+  it("소수점은 하나의 앵커로 유지한다", () => {
+    assert.ok(extractNumericAnchors("F1은 0.87로 측정되었다").includes("0.87"));
+  });
+
+  it("한 자리 숫자는 우연 일치가 잦아 제외한다", () => {
+    assert.deepEqual(extractNumericAnchors("담당 인력 3인"), []);
+  });
+
+  it("중복 앵커는 한 번만 반환한다", () => {
+    assert.deepEqual(extractNumericAnchors("14건 확정, 14건 검수"), ["14"]);
+  });
+
+  it("문자열이 아니면 빈 배열", () => {
+    assert.deepEqual(extractNumericAnchors(null), []);
+  });
+});
+
+describe("findMissingAnchors", () => {
+  const parent = "A사는 2026-07-15 서면을 제출했고 인용 가능성은 75~85%로 평가되었다. 증거 목록은 총 14건이다.";
+
+  it("모든 앵커가 자식에 남으면 누락 없음", () => {
+    const children = [
+      "A사는 2026-07-15 서면을 제출했다",
+      "인용 가능성은 75~85%로 평가되었다",
+      "증거 목록은 총 14건이다"
+    ];
+    assert.deepEqual(findMissingAnchors(parent, children), []);
+  });
+
+  it("명제 하나가 통째로 빠지면 해당 앵커를 보고한다", () => {
+    const children = [
+      "A사는 2026-07-15 서면을 제출했다",
+      "인용 가능성은 75~85%로 평가되었다"
+    ];
+    assert.deepEqual(findMissingAnchors(parent, children), ["14"]);
+  });
+
+  it("표기가 달라져도 구성 숫자가 남으면 보존으로 본다", () => {
+    const children = [
+      "A사는 2026년 07월 15일 서면을 제출했다",
+      "인용 가능성은 75%에서 85% 사이로 평가되었다",
+      "증거 목록은 14건이다"
+    ];
+    assert.deepEqual(findMissingAnchors(parent, children), []);
+  });
+
+  it("자릿수 구분자 유무가 판정을 바꾸지 않는다", () => {
+    assert.deepEqual(findMissingAnchors("예상 비용 1,200만 원", ["예상 비용은 1200만 원이다"]), []);
+    assert.deepEqual(findMissingAnchors("예상 비용 1200만 원", ["예상 비용은 1,200만 원이다"]), []);
+  });
+
+  it("수치 앵커가 없는 원문은 판정 대상이 아니다", () => {
+    assert.deepEqual(findMissingAnchors("담당자는 절차를 정리했다", ["담당자가 절차를 정리했다"]), []);
+  });
+
+  it("자식이 비어 있으면 모든 앵커가 누락으로 보고된다", () => {
+    assert.deepEqual(findMissingAnchors("총 14건", []), ["14"]);
+  });
+});


### PR DESCRIPTION
이슈 #33-1 대응.

## 문제

`splitLongFragments`는 원문을 문자 단위로 자르지 않고 LLM에 원자적 사실 재작성을 요청한다. 기존 게이트(`split-gate.js`)는 자식 개별 품질만 검사하고 자식 합집합이 원문을 덮는지는 보지 않으므로, 명제 하나가 통째로 누락된 상태에서도 자식 수가 `minItems`만 넘으면 원본이 tombstone 처리됐다.

실제 LLM 체인으로 측정한 결과 성공한 분할 18회 중 3회(16.7%)에서 원문 명제가 사라졌고, 그 경우에도 원본은 100% tombstone됐다. 누락된 앵커 3건은 전부 수치였다.

## 변경

- `lib/memory/consolidate/split-gate.js`: 순수 함수 `extractNumericAnchors`, `findMissingAnchors` 추가.
- `lib/memory/consolidate/ConsolidatorGC.js`: `minItems` 검사 직후, `_commitSplit` 직전에 대조한다. 자식이 아직 저장 전이라 롤백 경로가 없다. 유실 시 `split_attempt_failed_at`을 갱신하고 `anchor_loss`로 중단한다.
- `lib/memory/consolidate/split-metrics.js`: reason 라벨 문서화.
- `docs/configuration.md`, `docs/operations/llm-providers.md`: 판정 규칙과 메트릭 반영.

## 판정 규칙

날짜 `2026-07-15`는 `2026`/`07`/`15`로, 범위 `75~85`는 `75`/`85`로 분해 비교하므로 표기가 바뀌어도 구성 숫자가 남으면 보존으로 본다. 자릿수 구분자는 무시한다. 한 자리 숫자와 수치가 전혀 없는 원문은 판정 대상에서 제외한다.

이 정규화는 측정 단계에서 앵커 136개에 적용해 오탐 0건을 확인한 규칙을 그대로 옮긴 것이다. 한 자리 숫자 제외로 인한 오류는 과차단이 아니라 미검출 방향이다.

## 대안 검토

LLM 재검증은 호출 비용이 두 배가 되고 같은 모델이 같은 누락을 반복할 위험이 있어 채택하지 않았다. 임베딩 유사도는 명제 누락과 표현 변경을 구분하지 못한다. 이슈에서 제안된 고유명사 교집합 검사는 저장소에 NER이 없고 한국어 고유명사 판별 신뢰도가 낮아 채택하지 않았다. 측정에서 관측된 실제 유실이 전부 수치 앵커였으므로 수치만으로 검출된다.

시제·서법 변조 검사는 넣지 않았다. 45회 측정에서 0건이라 구현 근거가 없다.

## 검증

| 항목 | 결과 |
|-|-|
| 신규 유닛 테스트 | 15건 통과 |
| `npm test` | 2297 pass / 0 fail |
| `npm run lint` | 0 errors |

신규 테스트는 게이트 통과·차단·backoff 기록 세 경로와 표기 변형 대조를 덮는다. 실제 LLM 체인 기준 재측정 결과는 별도 코멘트로 첨부한다.