### PR TITLE
release: 5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [5.4.0] - 2026-08-02
+
+### Fixed
+- `splitLongFragments`가 생성한 자식 파편이 `keywords`를 빈 배열로 저장해 키워드 배열 교집합(`keywords && $1`)을 사용하는 검색 경로에서 조회되지 않던 문제 수정 (#32). 자식 본문에서 `FragmentFactory.extractKeywords` 결과를 추출해 저장한다. 기존 파편은 `scripts/backfill-split-keywords.js`로 소급 처리한다(dryRun 기본, `--execute`로 반영).
+- 분할된 원본 파편이 물리 삭제될 수 있던 문제 수정 (#33). `deleteExpired`의 utility 분기에는 `valid_to` 조건도 링크 보호도 없는데 분할은 원본을 `valid_to` 설정과 함께 importance 하향·`cold` 강등 처리하므로 anchor/permanent 보호가 적용되지 않았다. 자식이 남아 있는 원본을 삭제 후보에서 제외한다.
+- E2E `group-key-isolation` 스위트가 `api_keys`에 없는 key_id로 파편을 저장해 외래키 위반으로 실패하던 문제 수정. 시드 키를 선삽입하고 teardown에서 시드 파편을 물리 삭제해 재실행 가능성을 확보했다.
+- `lib/memory/memory-schema.sql`이 `content_hash` 전역 UNIQUE 인덱스를 생성해, migration-031이 도입한 키별 partial unique index(`uq_frag_hash_master`, `uq_frag_hash_per_key`)와 상충하던 문제 수정. 스키마 파일을 재적용할 때 키별 유일성이 전역 유일성으로 되돌아갔다.
+
+### Added
+- 분할 앵커 커버리지 게이트. 분할은 원문을 자르지 않고 LLM이 다시 쓰므로 명제 하나가 통째로 누락될 수 있는데, 기존에는 자식 수가 `minItems`만 넘으면 원본을 대체했다. 자식 저장 직전에 원문의 수치 앵커(날짜·금액·비율·측정값)가 자식 합집합에 남아 있는지 대조하고, 빠진 것이 있으면 원본을 유지한 채 중단한다. 날짜 `2026-07-15`는 `2026`/`07`/`15`로, 범위 `75~85`는 `75`/`85`로 분해 비교하므로 표기 변형은 통과한다.
+- `memento_consolidate_split_skipped_total`에 `anchor_loss` reason 라벨 추가.
+- `scripts/backfill-split-keywords.js`.
+
+### Changed
+- Antigravity CLI provider(`agy-cli`) 추가. `LLM_PRIMARY`/`LLM_FALLBACKS`에서 선택 가능하며 `--print --mode plan --sandbox`로 실행되어 파일 수정과 도구 승인을 하지 않는다.
+
 ## [5.3.1] - 2026-07-27
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,19 +2,20 @@
 
 AI 에이전트가 AnchorMind 기억 서버를 최대 효율로 활용하기 위한 기술 레퍼런스.
 
-## 현재 버전: v5.0.1
+## 현재 버전: v5.4.0
 
-AnchorMind 서버는 AI 에이전트의 세션 간 장기 기억을 파편(Fragment) 단위로 영속화하고, 20개 도구를 통해 저장·검색·연결·반성 기능을 제공한다.
+AnchorMind 서버는 AI 에이전트의 세션 간 장기 기억을 파편(Fragment) 단위로 영속화하고, 18개 도구를 통해 저장·검색·연결·반성 기능을 제공한다.
 
 주요 현재 기능:
 
 - `batch_remember`는 동기(기본)와 비동기(`async: true`) 두 모드를 지원한다. 비동기 모드에서는 선검증 후 Redis 큐에 적재하고 `{async, accepted, jobId}`를 즉시 반환하며, 워커가 ack·재시도(최대 3회)·dead-letter·기동 복구(RPOPLPUSH reliable queue)로 at-least-once 처리를 보장한다. `batch_status(jobId)`로 처리 상태(queued/processing/completed/dead)를 조회한다. Redis 비활성 환경에서는 자동으로 동기 모드로 폴백한다. `batch_remember`와 `memory_consolidate`는 표준 단일 JSON-RPC 응답으로 반환되며 `stream` 파라미터는 동작하지 않는다(하위 호환 유지).
-- 검색은 3계층(L1 키워드 → L2 pgvector 시맨틱 → L3 RRF 하이브리드)으로 자동 라우팅되며, `computeRecallScore` 함수가 cross-encoder reranker 결과에 topic/keyword 직접 일치 신호를 log 정규화된 가산항으로 반영한다. 시맨틱 임계값 기본값은 0.5이고, `SearchParamAdaptor`가 50회 이상 샘플 축적 후 키별·시간대별로 임계값을 자동 조정한다.
+- 검색은 3계층(L1 키워드 → L2 pgvector 시맨틱 → L3 RRF 하이브리드)으로 자동 라우팅되며, `computeRecallScore` 함수가 cross-encoder reranker 결과에 topic/keyword 직접 일치 신호를 log 정규화된 가산항으로 반영한다. 시맨틱 임계값 기본값은 0.4이고, `SearchParamAdaptor`가 50회 이상 샘플 축적 후 키별·시간대별로 임계값을 자동 조정한다.
 - 형태소 분석은 로컬 CPU 분석기(`MorphemeTokenizer`)가 담당한다. 한글 garu-ko·영어 PorterStemmer·중국어 @node-rs/jieba·일본어 kuromoji로 라우팅하며, 벤치마크 기준 1.06ms/call 수준이다. `MEMENTO_MORPHEME_TOKENIZER=llm` 설정 시에만 LLM 경로가 활성화된다.
 - 코어 도구는 MCP `title` + `annotations`(readOnlyHint/idempotentHint/openWorldHint) 메타데이터를 포함한다. Codex Desktop 등 deferred/lazy 로딩 클라이언트를 위한 재검색 가이드가 서버 initialize instructions에 포함된다.
 - recall/context/reflect 응답 `_meta`에 `serverTime { iso, epoch_ms, display_kst, timezone }` 필드가 포함되어 LLM 클라이언트가 매 응답마다 서버 현재 시각을 재확인할 수 있다.
 - `tool_reflect` 응답에 `_meta.link_suggestions[]`가 포함된다. 이 목록은 schema-fit gate를 통과하지 못해 자동 링크되지 않은 인과 관계 후보다. LLM은 후보를 검토하여 정당한 인과로 판단되는 항목만 `link(fromId, toId, relationType=...)` 도구로 명시 호출한다.
 - recall/context 응답에서 `_meta.serverTime.display_kst` 또는 `_meta.serverTime.iso`로 현재 시점을 재확인하고 파편의 `created_at`·`age_days`와 대조하여 stale 여부를 판단한다. 응답 메타에 명시된 서버 시각이 자체 추정 시각과 다르면 서버 시각이 정답이다.
+- 긴 파편 자동 분할(`splitLongFragments`)은 자식 파편에 본문 기반 keywords를 부여하므로 분할된 내용도 키워드 검색으로 회수된다. 자식 합집합이 원문의 수치 앵커(날짜·금액·비율)를 모두 담지 못하면 분할을 중단하고 원문을 그대로 유지하며, 자식이 남아 있는 원문은 GC 물리 삭제 대상에서 제외된다.
 - `lib/storage/` 어댑터 계층이 `getStorage()` 팩토리 형태로 존재하며, `MEMENTO_STORAGE` 환경변수로 storage 백엔드를 선택한다.
 - 검색 레이어는 `lib/memory/read/SearchScope.js`를 통해 `(workspace, caseId, resolutionStatus, phase, affect, keyId)` scope를 처음부터 정합 적용한다.
 - 실제 로직은 `lib/memory/processors/` 4개 클래스(MemoryRememberer·MemoryRecaller·MemoryReflector·MemoryLinker)와 `lib/memory/` 하위 6개 서브디렉토리(`read/`, `write/`, `link/`, `consolidate/`, `embedding/`, `signals/`)로 구성된다.

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -803,6 +803,8 @@ Fragments stored with `scope: "session"` serve as session working memory. They a
 
 Fragments marked `isAnchor: true` are permanently excluded from MemoryConsolidator's decay and deletion regardless of their tier. Even with importance as low as 0.1, they will not be deleted. Use this for knowledge that must never be lost.
 
+A source fragment split by `splitLongFragments` is excluded from expiry deletion while at least one child with `source = 'split:{source id}'` remains. The split marks the source with `valid_to` and lowers its importance and tier to `cold`, so without this protection the source would be physically deleted on utility grounds and only the children would survive. Once every child is gone, the normal GC rules apply again.
+
 Stale thresholds (days): procedure=30, fact=60, decision=90, default=60. Adjust in `config/memory.js` under `MEMORY_CONFIG.staleThresholds`.
 
 ---

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -415,6 +415,10 @@ Individual activation flags for the 3 stages that involve LLM rewriting and can 
 
 A stage with its flag set to `false` emits `status: "skipped"` and proceeds to the next stage. `compressOldFragments` defaults to `false` because it modifies original fragment content.
 
+Split children receive their `keywords` from their own body via `FragmentFactory.extractKeywords`, the same path `remember` uses. The parent's keywords are not copied.
+
+Anchor coverage check for `splitLongFragments`: the split rewrites the source through an LLM rather than cutting it, so an entire proposition can go missing. Right before the children are stored, the numeric anchors of the source (dates, amounts, ratios, measurements) are matched against the union of the children. If any anchor is absent, no child is stored, the original is left intact, `split_attempt_failed_at` is refreshed, and `memento_consolidate_split_skipped_total{reason="anchor_loss"}` is incremented. A date such as `2026-07-15` is compared as `2026`/`07`/`15` and a range such as `75~85` as `75`/`85`, so rephrasing passes as long as the component digits survive. Digit group separators are ignored; single digits and sources without any numeric token are excluded from the check.
+
 ### SearchParamAdaptor (Automatic Search Parameter Learning)
 
 SearchParamAdaptor operates automatically without any separate environment variables. It uses the `semanticSearch.minSimilarity` value from `config/memory.js` as the default. After 50 or more searches, the learned value per key_id x query_type x hour combination replaces the default.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -463,6 +463,8 @@ LLM 재작성이 수반되어 파편 내용을 변경할 수 있는 3개 stage�
 
 분할 자식 품질 게이트(`split-gate.js`): 최소 길이(`minChildLength`) 미달·대체 문자(`�`) 포함·CJK/가나 혼입(한글 본문 기준)·대명사/메타 시작 토큰이면 reject. fact 타입 자식의 importance가 클램프 후 0.4 미만이면 저장 차단.
 
+자식 파편의 `keywords`는 `remember` 경로와 동일하게 자식 본문에서 추출된다(`FragmentFactory.extractKeywords`). 부모의 keywords를 복사하지 않는다.
+
 Phase 1(gate-only)에서 통과 자식 수 < `minItems`이면 DB insert 없이 해당 파편의 `split_attempt_failed_at`을 갱신하고 `memento_consolidate_split_skipped_total{reason="low_yield"}`를 증가시킨다. 분할 성공 시 원본은 `valid_to = NOW()`, `ttl_tier = 'cold'`, `importance = GREATEST(0.2, importance × 0.3)` 처리된다.
 
 앵커 커버리지 검사: 분할은 원문을 자르지 않고 LLM이 다시 쓰므로 명제 하나가 통째로 누락될 수 있다. 자식 저장 직전에 원문의 수치 앵커(날짜·금액·비율·측정값)가 자식 합집합에 모두 남아 있는지 대조하고, 하나라도 빠지면 자식을 저장하지 않고 원본을 그대로 둔다. 이때 `split_attempt_failed_at`을 갱신하고 `memento_consolidate_split_skipped_total{reason="anchor_loss"}`를 증가시킨다. 날짜 `2026-07-15`는 `2026`/`07`/`15`로, 범위 `75~85`는 `75`/`85`로 분해 비교하므로 표기가 바뀌어도 구성 숫자가 남으면 보존으로 판정한다. 자릿수 구분자는 무시하며, 한 자리 숫자와 수치가 전혀 없는 원문은 판정 대상에서 제외한다.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anchormind-mcp",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anchormind-mcp",
-      "version": "5.3.1",
+      "version": "5.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anchormind-mcp",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "license": "Apache-2.0",
   "description": "Fragment-Based Memory MCP Server",
   "main": "server.js",


### PR DESCRIPTION
## 포함 변경

| PR | 내용 |
|-|-|
| #34 | Antigravity CLI provider(`agy-cli`) 추가 |
| #35 | E2E `group-key-isolation` 시드 키 선삽입, `memory-schema.sql`의 `content_hash` 전역 unique index 제거 |
| #36 | split 자식 파편 키워드 생성 + 소급 백필 스크립트 (이슈 #32) |
| #37 | 분할 자식이 남은 원본 파편 GC 보존 (이슈 #33) |
| #38 | 분할 앵커 커버리지 게이트 (이슈 #33) |

## 문서 현행화

- `CHANGELOG.md`: 5.4.0 항목.
- `SKILL.md`: 버전 v5.0.1 → v5.4.0, 도구 수 20 → 18(실제 등록 수), 시맨틱 임계값 기본값 0.5 → 0.4(5.2.3에서 변경됨), 분할 무결성 동작 추가.
- `docs/configuration.md`: 자식 keywords 추출 경로, 앵커 커버리지 검사.
- `docs/configuration.en.md`: 위 두 항목 영문 반영(기존 누락).
- `docs/architecture.en.md`: split 원본 GC 보호 영문 반영(기존 누락).

앞선 PR에서 이미 반영된 문서: `docs/architecture.md`, `docs/operations/llm-providers.md`, `docs/operations/maintenance.md`.

## 운영 반영 현황

배포는 이미 완료됐고 `memento-mcp.service`가 병합된 main으로 구동 중이다. 운영 DB 키워드 백필도 실행해 split 자식 3,982건을 갱신했으며 잔여 0건이다.

## 검증

| 항목 | 결과 |
|-|-|
| `npm test` | 2297 pass / 0 fail |
| `npm run lint` | 0 errors |
| `npm run lint:migrations` | passed |
| 버전 일치 | package.json / package-lock.json 모두 5.4.0 |