### PR TITLE
docs(install): consolidate 주기 기본값 표기 정정

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -279,7 +279,7 @@ DEDUP_BATCH_SIZE              - 시맨틱 dedup 배치 크기 (기본: 100)
 DEDUP_MIN_FRAGMENTS           - topic 내 최소 파편 수 (기본: 5)
 COMPRESS_AGE_DAYS             - 압축 대상 비활성 일수 (기본: 30)
 COMPRESS_MIN_GROUP            - 압축 그룹 최소 크기 (기본: 3)
-CONSOLIDATE_INTERVAL_MS       - consolidate 주기 (기본: 3600000 = 1시간)
+CONSOLIDATE_INTERVAL_MS       - consolidate 주기 (기본: 21600000 = 6시간)
 ALLOWED_ORIGINS               - CORS 허용 Origin 목록 (쉼표 구분)
 RERANKER_MODEL                - in-process ONNX 모델 선택: minilm (기본, 영어 전용) 또는 bge-m3 (다국어, 비영어권 권장)
 LLM_PRIMARY                   - 주 LLM provider (기본: gemini-cli). gemini-cli, agy-cli, codex-cli, opencode-cli, anthropic 등


### PR DESCRIPTION
`docs/INSTALL.md`의 `CONSOLIDATE_INTERVAL_MS` 기본값이 `3600000 = 1시간`으로 적혀 있으나 `config/memory.js:205`의 실제 기본값은 `21600000`(6시간)이다.

`docs/configuration.md`, `docs/configuration.en.md`, `docs/architecture.md`, `docs/architecture.en.md`, `docs/internals.en.md`는 모두 6시간으로 기술하고 있어 이 파일만 어긋나 있었다. `docs/INSTALL.en.md`에는 해당 항목이 없다.