### PR TITLE
fix(amend): 케이스 상태 갱신 지원 및 무시된 파라미터 보고

### DIFF
--- a/lib/memory/migrations/migration-038-fragment-versions-case-fields.sql
+++ b/lib/memory/migrations/migration-038-fragment-versions-case-fields.sql
@@ -1,0 +1,20 @@
+-- migration-038-fragment-versions-case-fields.sql
+-- 작성자: 최진호
+-- 작성일: 2026-08-02
+-- 목적: amend가 케이스 상태(resolution_status, outcome, phase)를 갱신할 수 있게 되면서
+--       변경 전 상태를 이력 테이블에도 보존한다. 세 컬럼 모두 nullable이므로
+--       구버전 writer와 혼재되는 롤링 배포 구간에서도 호환된다.
+-- 멱등: ADD COLUMN IF NOT EXISTS
+
+
+ALTER TABLE agent_memory.fragment_versions
+  ADD COLUMN IF NOT EXISTS resolution_status TEXT,
+  ADD COLUMN IF NOT EXISTS outcome           TEXT,
+  ADD COLUMN IF NOT EXISTS phase             TEXT;
+
+COMMENT ON COLUMN agent_memory.fragment_versions.resolution_status
+  IS 'amend 직전의 케이스 해결 상태. 종결 전후 대조용.';
+COMMENT ON COLUMN agent_memory.fragment_versions.outcome
+  IS 'amend 직전의 케이스 결과 요약.';
+COMMENT ON COLUMN agent_memory.fragment_versions.phase
+  IS 'amend 직전의 작업 단계.';

--- a/lib/memory/processors/MemoryRememberer.js
+++ b/lib/memory/processors/MemoryRememberer.js
@@ -23,6 +23,13 @@ import { extractRequestCtx }            from "../keyId.js";
 import { normalizeKeywords }            from "../write/FragmentFactory.js";
 import { validateContentInput }         from "../contentGuard.js";
 
+/** amend가 실제로 반영하는 파라미터. 이 목록 밖의 키는 조용히 무시하지 않고 호출자에게 알린다. */
+const AMENDABLE_PARAMS = new Set([
+  "id", "content", "topic", "keywords", "type", "importance", "isAnchor",
+  "supersedes", "assertionStatus", "resolutionStatus", "outcome", "phase",
+  "agentId", "dryRun"
+]);
+
 export class MemoryRememberer {
   /**
    * @param {Object} deps
@@ -729,9 +736,36 @@ export class MemoryRememberer {
       return { updated: false, error: "id is required" };
     }
 
+    /** 지원하지 않는 필드만 전달된 호출을 성공으로 보고하지 않는다.
+     *  스키마 검증을 하지 않는 클라이언트에서도 조용한 무시가 발생하지 않게 서버에서 판정한다. */
+    const unsupportedFields = Object.keys(params)
+      .filter(k => !AMENDABLE_PARAMS.has(k) && !k.startsWith("_"));
+    const suppliedFields = Object.keys(params)
+      .filter(k => k !== "id" && k !== "dryRun" && k !== "agentId" && AMENDABLE_PARAMS.has(k));
+
+    if (suppliedFields.length === 0 && unsupportedFields.length > 0) {
+      return {
+        updated: false,
+        error  : "No amendable fields supplied",
+        unsupportedFields
+      };
+    }
+
     const { agentId, keyId, groupKeyIds } = extractRequestCtx(params, { groupKeyIdsFallback: 'amend' });
     const existing    = await this.store.getById(params.id, agentId, keyId, groupKeyIds);
     if (!existing) {
+      /** 만료 파편과 미존재·권한 부족을 구분한다. 만료 파편은 이력이므로 수정 대상이 아니다. */
+      const expired = await this.store.getById(
+        params.id, agentId, keyId, groupKeyIds, { includeExpired: true }
+      ).catch(() => null);
+
+      if (expired) {
+        return {
+          updated: false,
+          error  : "Fragment is expired (valid_to set) and cannot be amended",
+          validTo: expired.valid_to ?? null
+        };
+      }
       return { updated: false, error: "Fragment not found or no permission" };
     }
 
@@ -747,6 +781,9 @@ export class MemoryRememberer {
       if (params.importance!== undefined) wouldBe.importance  = params.importance;
       if (params.isAnchor  !== undefined) wouldBe.is_anchor   = params.isAnchor;
       if (params.assertionStatus !== undefined) wouldBe.assertion_status = params.assertionStatus;
+      if (params.resolutionStatus !== undefined) wouldBe.resolution_status = params.resolutionStatus;
+      if (params.outcome   !== undefined) wouldBe.outcome     = params.outcome;
+      if (params.phase     !== undefined) wouldBe.phase       = params.phase;
 
       return {
         dryRun   : true,
@@ -777,6 +814,9 @@ export class MemoryRememberer {
     if (params.importance !== undefined)      updates.importance       = params.importance;
     if (params.isAnchor !== undefined)        updates.is_anchor        = params.isAnchor;
     if (params.assertionStatus !== undefined) updates.assertion_status = params.assertionStatus;
+    if (params.resolutionStatus !== undefined) updates.resolution_status = params.resolutionStatus;
+    if (params.outcome !== undefined)          updates.outcome           = params.outcome;
+    if (params.phase !== undefined)            updates.phase             = params.phase;
 
     const result = await this.store.update(params.id, updates, agentId, keyId, existing);
 
@@ -823,6 +863,26 @@ export class MemoryRememberer {
           this.caseEventStore.addEvidence(existing.id, event_id, "produced_by").catch(() => {})
         ).catch(err => logWarn(`[MemoryRememberer] amend event recording failed: ${err.message}`));
       }
+    }
+
+    /** 케이스 종결 기록 (fire-and-forget). resolved 전환 시에만 남긴다. */
+    if (
+      params.resolutionStatus === "resolved" &&
+      existing.resolution_status !== "resolved" &&
+      existing.case_id &&
+      this.caseEventStore
+    ) {
+      this.caseEventStore.append({
+        case_id           : existing.case_id,
+        session_id        : existing.session_id ?? null,
+        event_type        : "case_closed",
+        summary           : (params.outcome || existing.content || "").slice(0, 200),
+        source_fragment_id: existing.id,
+        entity_keys       : existing.keywords || [],
+        key_id            : keyId
+      }).then(({ event_id }) =>
+        this.caseEventStore.addEvidence(existing.id, event_id, "produced_by").catch(() => {})
+      ).catch(err => logWarn(`[MemoryRememberer] case close event recording failed: ${err.message}`));
     }
 
     return { updated: true, fragment: result };

--- a/lib/memory/read/FragmentReader.js
+++ b/lib/memory/read/FragmentReader.js
@@ -95,7 +95,9 @@ export class FragmentReader {
 
   async getById(id, agentId = "default", keyId = null, groupKeyIds = [], opts = {}) {
     const agentCond = this.#agentScopeCond("$2", opts.includePeerAgents === true);
-    const baseWhere = `id = $1 AND ${agentCond} AND valid_to IS NULL`;
+    /** includeExpired는 만료 사유 판별용이다. 일반 조회 경로는 기본값(유효 파편만)을 유지한다. */
+    const validCond = opts.includeExpired === true ? "" : " AND valid_to IS NULL";
+    const baseWhere = `id = $1 AND ${agentCond}${validCond}`;
     let   keyFilter = "";
     const params    = [id, agentId];
 
@@ -106,7 +108,7 @@ export class FragmentReader {
       `SELECT id, content, topic, keywords, type, importance, utility_score,
                     source, linked_to, agent_id, access_count,
                     accessed_at, created_at, ttl_tier, verified_at, is_anchor, key_id,
-                    context_summary, session_id,
+                    context_summary, session_id, valid_to,
                     case_id, goal, outcome, phase, resolution_status, assertion_status
              FROM ${SCHEMA}.fragments WHERE ${baseWhere}${keyFilter}`,
       params

--- a/lib/memory/write/FragmentWriter.js
+++ b/lib/memory/write/FragmentWriter.js
@@ -279,7 +279,8 @@ export class FragmentWriter {
       const lookup = await queryWithAgentVector(agentId,
         `SELECT id, content, topic, keywords, type, importance,
                 source, linked_to, agent_id, access_count,
-                accessed_at, created_at, ttl_tier, verified_at, is_anchor, key_id
+                accessed_at, created_at, ttl_tier, verified_at, is_anchor, key_id,
+                resolution_status, outcome, phase
          FROM ${SCHEMA}.fragments WHERE id = $1`,
         [id]
       );
@@ -305,11 +306,13 @@ export class FragmentWriter {
       /** SET LOCAL은 파라미터 바인딩 미지원 — safeAgent는 [^a-zA-Z0-9_\-]로 정제됨 */
       await client.query(`SET LOCAL app.current_agent_id = '${safeAgent}'`);
 
-      /** 수정 전 상태 아카이빙 (버전 관리) */
+      /** 수정 전 상태 아카이빙 (버전 관리).
+       *  케이스 상태 3종은 migration-038로 추가됐으며, UPDATE와 동일 트랜잭션에서 기록한다. */
       await client.query(
         `INSERT INTO ${SCHEMA}.fragment_versions
-                  (fragment_id, content, topic, keywords, type, importance, amended_by)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+                  (fragment_id, content, topic, keywords, type, importance, amended_by,
+                   resolution_status, outcome, phase)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
         [
           existing.id,
           existing.content,
@@ -317,7 +320,10 @@ export class FragmentWriter {
           existing.keywords,
           existing.type,
           existing.importance,
-          agentId
+          agentId,
+          existing.resolution_status ?? null,
+          existing.outcome ?? null,
+          existing.phase ?? null
         ]
       );
 
@@ -425,6 +431,25 @@ export class FragmentWriter {
     if (updates.assertion_status !== undefined) {
       setClauses.push(`assertion_status = $${paramIdx}`);
       params.push(updates.assertion_status);
+      paramIdx++;
+    }
+
+    /** 케이스 상태 전이. INSERT 경로에만 있던 컬럼을 amend에서도 갱신한다. */
+    if (updates.resolution_status !== undefined) {
+      setClauses.push(`resolution_status = $${paramIdx}`);
+      params.push(updates.resolution_status);
+      paramIdx++;
+    }
+
+    if (updates.outcome !== undefined) {
+      setClauses.push(`outcome = $${paramIdx}`);
+      params.push(updates.outcome);
+      paramIdx++;
+    }
+
+    if (updates.phase !== undefined) {
+      setClauses.push(`phase = $${paramIdx}`);
+      params.push(updates.phase);
       paramIdx++;
     }
 

--- a/lib/tools/memory-schemas.js
+++ b/lib/tools/memory-schemas.js
@@ -712,6 +712,23 @@ export const amendDefinition = {
                        "case_id가 있는 파편은 변경 시 verification_passed/verification_failed 이벤트가 자동 기록된다.",
         examples   : ["verified", "rejected", "inferred"]
       },
+      resolutionStatus: {
+        type       : "string",
+        enum       : ["open", "resolved", "abandoned"],
+        description: "케이스 해결 상태 변경. 대표 파편에 resolved를 기록하여 케이스를 종결한다. " +
+                       "case_id가 있는 파편은 resolved 전환 시 case_closed 이벤트가 자동 기록된다.",
+        examples   : ["resolved", "abandoned", "open"]
+      },
+      outcome: {
+        type       : "string",
+        description: "케이스 종결 결과 요약. resolutionStatus='resolved'와 함께 기록한다.",
+        examples   : ["nginx location 우선순위 수정으로 인증서 갱신 성공"]
+      },
+      phase: {
+        type       : "string",
+        description: "작업 단계 변경 (예: planning, debugging, implementation, verification).",
+        examples   : ["debugging", "verification", "completed"]
+      },
       agentId: COMMON_PARAMS.agentId,
       dryRun: {
         type       : "boolean",

--- a/tests/unit/amend-case-fields.test.js
+++ b/tests/unit/amend-case-fields.test.js
@@ -1,0 +1,59 @@
+/**
+ * Unit tests: amend의 케이스 필드 갱신과 미지원 필드·만료 파편 처리.
+ *
+ * SKILL.md와 lib/jsonrpc.js가 안내하는 케이스 종결 절차
+ * amend(id, resolutionStatus, outcome, phase)가 실제로 반영되는지 검증한다.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { amendDefinition } = await import("../../lib/tools/memory-schemas.js");
+
+describe("amend 스키마", () => {
+  const props = amendDefinition.inputSchema.properties;
+
+  it("케이스 종결 필드 3종을 노출한다", () => {
+    assert.ok(props.resolutionStatus, "resolutionStatus 필요");
+    assert.ok(props.outcome, "outcome 필요");
+    assert.ok(props.phase, "phase 필요");
+  });
+
+  it("resolutionStatus enum이 저장 경로와 일치한다", () => {
+    assert.deepEqual(props.resolutionStatus.enum, ["open", "resolved", "abandoned"]);
+  });
+
+  it("기존 필드가 유지된다", () => {
+    for (const k of ["id", "content", "topic", "keywords", "type", "importance",
+                     "isAnchor", "supersedes", "assertionStatus", "agentId", "dryRun"]) {
+      assert.ok(props[k], `${k}가 사라지면 안 된다`);
+    }
+  });
+});
+
+const { FragmentWriter } = await import("../../lib/memory/write/FragmentWriter.js");
+
+describe("FragmentWriter 갱신 허용 필드", () => {
+  const src = FragmentWriter.prototype._diffUpdatableFields.toString();
+
+  it("케이스 상태 3종을 SET 절 대상으로 포함한다", () => {
+    assert.ok(src.includes("resolution_status = $"), "resolution_status UPDATE 필요");
+    assert.ok(src.includes("outcome = $"), "outcome UPDATE 필요");
+    assert.ok(src.includes("phase = $"), "phase UPDATE 필요");
+  });
+
+  it("기존 갱신 필드가 유지된다", () => {
+    for (const col of ["content", "topic", "keywords", "type", "importance",
+                       "is_anchor", "assertion_status"]) {
+      assert.ok(src.includes(`${col} = $`), `${col} 갱신이 사라지면 안 된다`);
+    }
+  });
+});
+
+describe("FragmentReader.getById 만료 조회 옵션", () => {
+  it("includeExpired 미지정 시 valid_to IS NULL 조건을 유지한다", async () => {
+    const { FragmentReader } = await import("../../lib/memory/read/FragmentReader.js");
+    const src = FragmentReader.prototype.getById.toString();
+    assert.ok(src.includes("valid_to IS NULL"), "기본 경로는 유효 파편만 조회해야 한다");
+    assert.ok(src.includes("includeExpired"), "만료 포함 옵션이 있어야 한다");
+  });
+});


### PR DESCRIPTION
운영 피드백(2026-07-25)에서 보고된 amend 결함 2건을 수정한다.

## 문제

격리 DB에서 실제 코드 경로로 재현했다.

```
변경 전 {"resolution_status":"open","outcome":null,"phase":"planning"}
amend(resolutionStatus="resolved", outcome="...", phase="verification") → updated:true
변경 후 {"resolution_status":"open","outcome":null,"phase":"planning"}
```

세 필드가 `amendDefinition` 스키마에 없고 `additionalProperties` 제약도 없어 조용히 버려졌으며, 다른 필드가 없어도 `updated:true`가 반환됐다. `FragmentWriter`의 갱신 허용 필드 9종에도 케이스 컬럼이 없어 저장 계층까지 누락돼 있었다. `SKILL.md:1385`와 `lib/jsonrpc.js:260`은 이 사용법을 안내하고 있었으므로 문서가 아니라 구현이 어긋난 상태였다.

만료 파편 amend는 미존재 id와 동일한 `Fragment not found or no permission`을 반환해 원인을 구분할 수 없었다.

## 변경

- `lib/tools/memory-schemas.js`: `resolutionStatus`(enum open/resolved/abandoned), `outcome`, `phase` 추가.
- `lib/memory/processors/MemoryRememberer.js`: updates 매핑과 dryRun 시뮬레이션에 세 필드 반영. 반영 가능한 필드가 하나도 없으면 `updated:false` + `unsupportedFields` 반환. 만료 파편은 `includeExpired` 재조회로 구분해 `validTo`와 함께 전용 오류 반환. `resolved` 전환 시 `case_closed` 이벤트 기록.
- `lib/memory/write/FragmentWriter.js`: SET 절에 세 컬럼 추가. 변경 전 상태를 `fragment_versions`에 UPDATE와 동일 트랜잭션으로 아카이빙.
- `lib/memory/read/FragmentReader.js`: `getById`에 `includeExpired` 옵션. 기본 경로는 `valid_to IS NULL` 유지.
- `migration-038`: `fragment_versions`에 nullable 컬럼 3종 추가. 가산적 변경이라 구버전 writer와 혼재되는 롤링 배포에서도 호환된다.

만료 파편은 여전히 수정 불가다. `valid_to`가 설정된 파편은 이력이므로 수정 대상이 아니라는 기존 설계를 유지하고 오류만 구분한다.

## 검증

| 항목 | 결과 |
|-|-|
| 재현 스크립트 D4 | 세 필드 정상 반영 |
| 재현 스크립트 D5 | 만료/미존재 오류 구분됨 |
| 버전 이력 아카이빙 | 변경 전 `{open, null, planning}` 보존 확인 |
| 미지원 필드만 전달 | `{updated:false, unsupportedFields:["bogusField"]}` |
| `npm test` | 2303 pass / 0 fail |
| `npm run test:e2e` | 17 pass / 0 fail |
| `npm run lint` | 0 errors |
| `npm run lint:migrations` | passed |