### PR TITLE
fix(recall): type/topic 스코프를 시맨틱·시간창 경로에 정합 적용

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -17,7 +17,7 @@ AnchorMind 서버는 AI 에이전트의 세션 간 장기 기억을 파편(Fragm
 - recall/context 응답에서 `_meta.serverTime.display_kst` 또는 `_meta.serverTime.iso`로 현재 시점을 재확인하고 파편의 `created_at`·`age_days`와 대조하여 stale 여부를 판단한다. 응답 메타에 명시된 서버 시각이 자체 추정 시각과 다르면 서버 시각이 정답이다.
 - 긴 파편 자동 분할(`splitLongFragments`)은 자식 파편에 본문 기반 keywords를 부여하므로 분할된 내용도 키워드 검색으로 회수된다. 자식 합집합이 원문의 수치 앵커(날짜·금액·비율)를 모두 담지 못하면 분할을 중단하고 원문을 그대로 유지하며, 자식이 남아 있는 원문은 GC 물리 삭제 대상에서 제외된다.
 - `lib/storage/` 어댑터 계층이 `getStorage()` 팩토리 형태로 존재하며, `MEMENTO_STORAGE` 환경변수로 storage 백엔드를 선택한다.
-- 검색 레이어는 `lib/memory/read/SearchScope.js`를 통해 `(workspace, caseId, resolutionStatus, phase, affect, keyId)` scope를 처음부터 정합 적용한다.
+- 검색 레이어는 `lib/memory/read/SearchScope.js`를 통해 `(workspace, caseId, resolutionStatus, phase, affect, type, topic, keyId)` scope를 처음부터 정합 적용한다.
 - 실제 로직은 `lib/memory/processors/` 4개 클래스(MemoryRememberer·MemoryRecaller·MemoryReflector·MemoryLinker)와 `lib/memory/` 하위 6개 서브디렉토리(`read/`, `write/`, `link/`, `consolidate/`, `embedding/`, `signals/`)로 구성된다.
 
 ### LLM 동시성 제어

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ server.js  (HTTP 서버)
             │   ├── LinkedFragmentLoader.js 연결 파편 일괄 로드 (1-hop 이웃 배치 조회)
             │   ├── RecallSuggestionEngine.js recall 결과 분석 후 _suggestion 메타 생성
             │   ├── assistant-query.js    보조 조회 헬퍼
-            │   ├── SearchScope.js        검색 정합 필터 계약. workspace/caseId/resolutionStatus/phase/affect/keyId 캡슐화. applyTo(fragment) → boolean. L1 HotCache·L2·L3·Graph 각 호출 사이트에서 fragment 단위 필터링을 수행하며 _executeSearch는 별도 후처리 보정을 수행하지 않는다
+            │   ├── SearchScope.js        검색 정합 필터 계약. workspace/caseId/resolutionStatus/phase/affect/type/topic/keyId 캡슐화. applyTo(fragment) → boolean. L1 HotCache·L2·L3·Graph 각 호출 사이트에서 fragment 단위 필터링을 수행하며 _executeSearch는 별도 후처리 보정을 수행하지 않는다
             │   └── SearchSideEffects.js  검색 부작용 격리 모듈. commitSearchSideEffects()가 searchEventId를 동기 반환하고 SearchParamAdaptor.recordOutcome()을 fire-and-forget으로 호출. FragmentSearch는 검색 파이프라인에만 집중
             ├── write/                    쓰기 레이어 모듈
             │   ├── FragmentWriter.js     파편 쓰기 (insert, update, delete, incrementAccess, touchLinked)

--- a/docs/internals.en.md
+++ b/docs/internals.en.md
@@ -200,7 +200,7 @@ Admin module tests are planned to migrate to directly importing `assets/admin/mo
 
 ### Workspace Filter Propagation
 
-`FragmentSearch._buildSearchQuery()` normalizes the `workspace` value into `sq.workspace`. `_executeSearch()` passes it to L2 (keyword/topic) search options and as the 8th argument to L3 `searchBySemantic`.
+`FragmentSearch._buildSearchQuery()` normalizes the `workspace` value into `sq.workspace`. `_executeSearch()` passes it to L2 (keyword/topic) search options and as the `workspace` field of the L3 `searchBySemantic` options object. `searchBySemantic` takes `(queryEmbedding, opts)` rather than positional filters, and `opts` also carries the explicit `type` / `topic` scope.
 
 All six `FragmentReader` methods — `searchByKeywords`, `searchByTopic`, `searchBySemantic`, `searchByTimeRange`, `searchAsOf`, and `searchBySource` — support the `(workspace = $N OR workspace IS NULL)` condition. `_searchTemporal` also passes `workspace: sq.workspace` to `searchByTimeRange`.
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -28,7 +28,7 @@ MemoryManager는 thin facade다. 비즈니스 로직은 `lib/memory/processors/`
 | 모듈 | 역할 |
 |------|------|
 | `FragmentSearch` (`lib/memory/read/FragmentSearch.js`) | L1~L4 검색 파이프라인 조율 |
-| `SearchScope` (`lib/memory/read/SearchScope.js`) | workspace·caseId·resolutionStatus·phase·affect 5개 필드를 모든 검색 레이어에 일관 전달하는 정합 필터 계약 객체 |
+| `SearchScope` (`lib/memory/read/SearchScope.js`) | workspace·caseId·resolutionStatus·phase·affect·type·topic 7개 필드를 모든 검색 레이어에 일관 전달하는 정합 필터 계약 객체 |
 | `SearchSideEffects` (`lib/memory/read/SearchSideEffects.js`) | 검색 결과 확정 후 부작용(검색 이벤트 영속화, SearchParamAdaptor 학습 신호)을 단일 모듈로 격리 |
 
 검색 관련 모듈은 `lib/memory/read/`에 위치하며, 임포트 경로는 실제 파일 위치를 그대로 따른다.
@@ -81,7 +81,7 @@ recall(query)
   ├── L3 PostgreSQL 전문 검색 (형태소; MorphemeTokenizer 로컬 CPU 분석기 → morpheme_dict → tsquery)
   ├── L4 Cross-Encoder Reranker (RRF 상위 30건)
   ├── RRF 병합 (k=60)
-  ├── SearchScope.applyTo() 필터 — workspace·caseId·resolutionStatus·phase·affect 정합
+  ├── SearchScope.applyTo() 필터 — workspace·caseId·resolutionStatus·phase·affect·type·topic 정합
   │     _executeSearch() 내 각 레이어가 SearchScope 인스턴스를 공유하여 후처리 보정 불필요
   ├── 토큰 예산 절단 (tokenBudget)
   ├── valid_to 필터
@@ -99,7 +99,7 @@ recall(query)
 
 `pickFields`는 19개 화이트리스트(`id, content, type, importance, topic, ..., key_id, key_name`) 외 필드를 제거한다. 캐시 단계(L1 warm hit, RRF 병합 중간 객체)에는 적용하지 않아 캐시 효율을 보존한다.
 
-**SearchScope 계약:** `SearchScope.fromQuery(sq)` 정적 팩토리가 `_buildSearchQuery()` 반환 sq에서 scope 인스턴스를 생성한다. `scope.applyTo(fragment)` 메서드는 workspace, caseId, resolutionStatus, phase, affect 5개 필드를 동시 검사하여 false를 반환하는 경우 해당 파편을 결과에서 제외한다. HotCache·L3·Graph 호출 사이트가 모두 동일 인스턴스를 참조하므로 레이어별 파편 결과의 정합성이 보장된다. `_executeSearch()`는 별도의 후처리 보정을 수행하지 않는다.
+**SearchScope 계약:** `SearchScope.fromQuery(sq)` 정적 팩토리가 `_buildSearchQuery()` 반환 sq에서 scope 인스턴스를 생성한다. `scope.applyTo(fragment)` 메서드는 workspace, caseId, resolutionStatus, phase, affect, type, topic 7개 필드를 동시 검사하여 false를 반환하는 경우 해당 파편을 결과에서 제외한다. HotCache·L3·Graph 호출 사이트가 모두 동일 인스턴스를 참조하므로 레이어별 파편 결과의 정합성이 보장된다. `_executeSearch()`는 별도의 후처리 보정을 수행하지 않는다.
 
 ---
 

--- a/lib/memory/read/FragmentReader.js
+++ b/lib/memory/read/FragmentReader.js
@@ -370,14 +370,38 @@ export class FragmentReader {
   /**
    * 벡터 유사도 검색
    *
-   * @param {number[]}    queryEmbedding
-   * @param {number}      limit
-   * @param {number}      minSimilarity
-   * @param {string}      agentId
-   * @param {string|null} keyId - null: 마스터(전체), string: 해당 API 키 소유만
-   * @param {boolean}     includeSuperseded
+   * 필터가 12종을 넘어 위치 인자로는 순서 오류를 막기 어려우므로 옵션 객체를 받는다.
+   *
+   * @param {number[]} queryEmbedding
+   * @param {Object}   [opts]
+   * @param {number}   [opts.limit=10]
+   * @param {number}   [opts.minSimilarity=0.3]
+   * @param {string}   [opts.agentId="default"]
+   * @param {string|string[]|null} [opts.keyId] - null: 마스터(전체), 값: 해당 API 키 소유만
+   * @param {boolean}  [opts.includeSuperseded=false]
+   * @param {Object|null} [opts.timeRange]
+   * @param {string|null} [opts.workspace]
+   * @param {string|string[]|null} [opts.affect]
+   * @param {boolean}  [opts.morphemeOnly=false]
+   * @param {boolean}  [opts.includePeerAgents=false]
+   * @param {string|null} [opts.type]  - 지정 시 해당 type만 반환
+   * @param {string|null} [opts.topic] - 지정 시 해당 topic만 반환
    */
-  async searchBySemantic(queryEmbedding, limit = 10, minSimilarity = 0.3, agentId = "default", keyId = null, includeSuperseded = false, timeRange = null, workspace = null, affect = null, morphemeOnly = false, includePeerAgents = false) {
+  async searchBySemantic(queryEmbedding, opts = {}) {
+    const {
+      limit             = 10,
+      minSimilarity     = 0.3,
+      agentId           = "default",
+      keyId             = null,
+      includeSuperseded = false,
+      timeRange         = null,
+      workspace         = null,
+      affect            = null,
+      morphemeOnly      = false,
+      includePeerAgents = false,
+      type              = null,
+      topic             = null
+    } = opts;
     const vecStr     = vectorToSql(queryEmbedding);
     const conditions = [
       "f.embedding IS NOT NULL",
@@ -429,6 +453,19 @@ export class FragmentReader {
      */
     if (morphemeOnly) {
       conditions.push("f.morpheme_indexed = true");
+    }
+
+    /** 명시 type/topic 필터. L2에만 적용되던 것을 시맨틱 경로에도 정합 적용한다. */
+    if (type) {
+      conditions.push(`f.type = $${paramIdx}`);
+      params.push(type);
+      paramIdx++;
+    }
+
+    if (topic) {
+      conditions.push(`f.topic = $${paramIdx}`);
+      params.push(topic);
+      paramIdx++;
     }
 
     const result = await queryWithAgentVector(agentId,
@@ -501,6 +538,19 @@ export class FragmentReader {
     if (options.phase) {
       conditions.push(`phase = $${paramIdx}`);
       params.push(options.phase);
+      paramIdx++;
+    }
+
+    /** 명시 type/topic 필터 */
+    if (options.type) {
+      conditions.push(`type = $${paramIdx}`);
+      params.push(options.type);
+      paramIdx++;
+    }
+
+    if (options.topic) {
+      conditions.push(`topic = $${paramIdx}`);
+      params.push(options.topic);
       paramIdx++;
     }
 

--- a/lib/memory/read/FragmentSearch.js
+++ b/lib/memory/read/FragmentSearch.js
@@ -592,7 +592,10 @@ export class FragmentSearch {
         ...(sq.includePeerAgents === true ? { includePeerAgents: true } : {}),
         ...(sq.caseId           ? { caseId: sq.caseId } : {}),
         ...(sq.resolutionStatus ? { resolutionStatus: sq.resolutionStatus } : {}),
-        ...(sq.phase            ? { phase: sq.phase } : {})
+        ...(sq.phase            ? { phase: sq.phase } : {}),
+        /** type/topic 미전달 시 시간창 안의 모든 파편이 RRF에 2.0 가중으로 유입된다. */
+        ...(sq.type             ? { type: sq.type } : {}),
+        ...(sq.topic            ? { topic: sq.topic } : {})
       }
     );
   }
@@ -754,11 +757,19 @@ export class FragmentSearch {
         try {
           const morphemeVec = await this._morphemeIndex.textToMorphemeVector(query.text);
           if (!morphemeVec) return [];
-          return await this.store.searchBySemantic(
-            morphemeVec, Math.min(limit ?? 10, 10), minSimilarity,
-            agentId, keyId, query.includeSuperseded || false, timeRange,
-            query.workspace ?? null, null, true, query.includePeerAgents === true
-          );
+          return await this.store.searchBySemantic(morphemeVec, {
+            limit            : Math.min(limit ?? 10, 10),
+            minSimilarity,
+            agentId, keyId,
+            includeSuperseded: query.includeSuperseded || false,
+            timeRange,
+            workspace        : query.workspace ?? null,
+            affect           : null,
+            morphemeOnly     : true,
+            includePeerAgents: query.includePeerAgents === true,
+            type             : query.type ?? null,
+            topic            : query.topic ?? null
+          });
         } catch (morphErr) {
           logWarn(`[FragmentSearch] L3 morpheme sub-path failed: ${morphErr.message}`);
           return [];
@@ -766,11 +777,19 @@ export class FragmentSearch {
       })();
 
       const [results, morphemeResults] = await Promise.all([
-        this.store.searchBySemantic(
-          vec, limit ?? 10, minSimilarity,
-          agentId, keyId, query.includeSuperseded || false, timeRange,
-          query.workspace ?? null, query.affect ?? null, false, query.includePeerAgents === true
-        ),
+        this.store.searchBySemantic(vec, {
+          limit            : limit ?? 10,
+          minSimilarity,
+          agentId, keyId,
+          includeSuperseded: query.includeSuperseded || false,
+          timeRange,
+          workspace        : query.workspace ?? null,
+          affect           : query.affect ?? null,
+          morphemeOnly     : false,
+          includePeerAgents: query.includePeerAgents === true,
+          type             : query.type ?? null,
+          topic            : query.topic ?? null
+        }),
         morphemeProbe
       ]);
 

--- a/lib/memory/read/SearchScope.js
+++ b/lib/memory/read/SearchScope.js
@@ -33,6 +33,8 @@ export class SearchScope {
     resolutionStatus,
     phase,
     affect,
+    type,
+    topic,
     keyId = null,
     agentId = null,
     includePeerAgents = false
@@ -41,6 +43,8 @@ export class SearchScope {
     this.caseId            = caseId;
     this.resolutionStatus  = resolutionStatus;
     this.phase             = phase;
+    this.type              = type;
+    this.topic             = topic;
     /** affect는 배열로 정규화하여 보관. 미지정이면 null. */
     this.affectSet         = affect
       ? new Set(Array.isArray(affect) ? affect : [affect])
@@ -91,6 +95,15 @@ export class SearchScope {
       return false;
     }
 
+    /** type/topic: SQL 필터가 닿지 않는 레이어(graph 등)의 최종 방어선. */
+    if (this.type !== undefined && fragment.type !== this.type) {
+      return false;
+    }
+
+    if (this.topic !== undefined && fragment.topic !== this.topic) {
+      return false;
+    }
+
     return true;
   }
 
@@ -107,7 +120,9 @@ export class SearchScope {
       this.caseId            === undefined &&
       this.resolutionStatus  === undefined &&
       this.phase             === undefined &&
-      this.affectSet         === null
+      this.affectSet         === null &&
+      this.type              === undefined &&
+      this.topic             === undefined
     );
   }
 
@@ -124,6 +139,8 @@ export class SearchScope {
       resolutionStatus: sq.resolutionStatus,
       phase           : sq.phase,
       affect          : sq.affect,
+      type            : sq.type,
+      topic           : sq.topic,
       keyId           : sq.keyId            ?? null,
       agentId         : sq.agentId          ?? null,
       includePeerAgents: sq.includePeerAgents === true

--- a/lib/memory/write/FragmentStore.js
+++ b/lib/memory/write/FragmentStore.js
@@ -28,8 +28,8 @@ export class FragmentStore {
   getHistory(fragmentId, agentId, keyId, groupKeyIds, opts)           { return this.reader.getHistory(fragmentId, agentId, keyId, groupKeyIds, opts); }
   searchByKeywords(keywords, options)                                  { return this.reader.searchByKeywords(keywords, options); }
   searchByTopic(topic, options)                                        { return this.reader.searchByTopic(topic, options); }
-  searchBySemantic(queryEmbedding, limit, minSimilarity, agentId, keyId, includeSuperseded, timeRange, workspace, affect, morphemeOnly = false, includePeerAgents = false) {
-    return this.reader.searchBySemantic(queryEmbedding, limit, minSimilarity, agentId, keyId, includeSuperseded, timeRange, workspace, affect, morphemeOnly, includePeerAgents);
+  searchBySemantic(queryEmbedding, opts = {}) {
+    return this.reader.searchBySemantic(queryEmbedding, opts);
   }
   searchByTimeRange(from, to, options)                                  { return this.reader.searchByTimeRange(from, to, options); }
   searchAsOf(asOf, agentId, opts, keyId)                               { return this.reader.searchAsOf(asOf, agentId, opts, keyId); }

--- a/tests/unit/consistency-gate.test.js
+++ b/tests/unit/consistency-gate.test.js
@@ -89,12 +89,9 @@ describe("Consistency Gate — morpheme_indexed SQL 조건 검증", () => {
   test("morphemeOnly=false → SQL에 morpheme_indexed 조건 없음", async () => {
     capturedSql = "";
     const reader = new FragmentReader();
-    await reader.searchBySemantic(
-      [0.1, 0.2, 0.3],
-      10, 0.3, "default", null,
-      false, null, null, null,
-      false  /* morphemeOnly */
-    ).catch(() => {});
+    await reader.searchBySemantic([0.1, 0.2, 0.3], {
+      limit: 10, minSimilarity: 0.3, agentId: "default", morphemeOnly: false
+    }).catch(() => {});
 
     assert.ok(capturedSql.length > 0, "SQL이 캡처되어야 함");
     assert.ok(!capturedSql.includes("morpheme_indexed"),
@@ -104,12 +101,9 @@ describe("Consistency Gate — morpheme_indexed SQL 조건 검증", () => {
   test("morphemeOnly=true → SQL에 morpheme_indexed = true 조건 포함", async () => {
     capturedSql = "";
     const reader = new FragmentReader();
-    await reader.searchBySemantic(
-      [0.1, 0.2, 0.3],
-      10, 0.3, "default", null,
-      false, null, null, null,
-      true   /* morphemeOnly */
-    ).catch(() => {});
+    await reader.searchBySemantic([0.1, 0.2, 0.3], {
+      limit: 10, minSimilarity: 0.3, agentId: "default", morphemeOnly: true
+    }).catch(() => {});
 
     assert.ok(capturedSql.length > 0, "SQL이 캡처되어야 함");
     assert.ok(
@@ -121,12 +115,9 @@ describe("Consistency Gate — morpheme_indexed SQL 조건 검증", () => {
   test("morphemeOnly=true + keyId → 두 조건 모두 포함", async () => {
     capturedSql = "";
     const reader = new FragmentReader();
-    await reader.searchBySemantic(
-      [0.1, 0.2, 0.3],
-      5, 0.4, "default", "key-abc",
-      false, null, null, null,
-      true   /* morphemeOnly */
-    ).catch(() => {});
+    await reader.searchBySemantic([0.1, 0.2, 0.3], {
+      limit: 5, minSimilarity: 0.4, agentId: "default", keyId: "key-abc", morphemeOnly: true
+    }).catch(() => {});
 
     assert.ok(capturedSql.includes("morpheme_indexed = true"), "morpheme_indexed 조건 포함");
     assert.ok(capturedSql.includes("key_id"), "keyId 격리 조건 포함");

--- a/tests/unit/recall-peer-agents.test.js
+++ b/tests/unit/recall-peer-agents.test.js
@@ -60,16 +60,18 @@ describe("FragmentReader includePeerAgents", () => {
     assert.doesNotMatch(lastSql(), AGENT_COND);
   });
 
-  it("searchBySemantic 11번째 인자 true면 f.agent_id 격리 완화", async () => {
+  it("searchBySemantic includePeerAgents=true면 f.agent_id 격리 완화", async () => {
     const vec = new Array(4).fill(0.1);
-    await reader.searchBySemantic(vec, 5, 0.3, "a1", null, false, null, null, null, false, true);
+    await reader.searchBySemantic(vec, {
+      limit: 5, minSimilarity: 0.3, agentId: "a1", includePeerAgents: true
+    });
     assert.doesNotMatch(lastSql(), AGENT_COND);
     assert.match(lastSql(), PEER_COND);
   });
 
   it("searchBySemantic 기본은 격리 유지", async () => {
     const vec = new Array(4).fill(0.1);
-    await reader.searchBySemantic(vec, 5, 0.3, "a1");
+    await reader.searchBySemantic(vec, { limit: 5, minSimilarity: 0.3, agentId: "a1" });
     assert.match(lastSql(), AGENT_COND);
   });
 
@@ -93,9 +95,9 @@ describe("FragmentReader includePeerAgents", () => {
   it("FragmentStore.searchBySemantic이 includePeerAgents 옵션을 전달", async () => {
     const store = new FragmentStore();
     const vec = new Array(4).fill(0.1);
-    await store.searchBySemantic(
-      vec, 5, 0.3, "a1", null, false, null, null, null, false, true
-    );
+    await store.searchBySemantic(vec, {
+      limit: 5, minSimilarity: 0.3, agentId: "a1", includePeerAgents: true
+    });
     assert.doesNotMatch(lastSql(), AGENT_COND);
     assert.match(lastSql(), PEER_COND);
   });

--- a/tests/unit/search-scope-type-topic.test.js
+++ b/tests/unit/search-scope-type-topic.test.js
@@ -1,0 +1,82 @@
+/**
+ * Unit tests: type/topic 스코프가 시맨틱·시간창 경로와 사후 필터에 정합 적용되는지 검증.
+ *
+ * 기존에는 type 필터가 L1/L2에만 걸려, timeRange 지정 시 temporal 레이어가
+ * 타입 무관 파편을 수집하고 RRF에서 2.0 가중을 받아 상위를 점령했다.
+ */
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+let capturedSql = "";
+mock.module("../../lib/tools/db.js", {
+  exports: {
+    getPrimaryPool      : () => ({ query: async () => ({ rows: [] }) }),
+    queryWithAgentVector: async (_agent, sql) => { capturedSql = sql; return { rows: [] }; }
+  }
+});
+
+const { FragmentReader } = await import("../../lib/memory/read/FragmentReader.js");
+const { SearchScope }    = await import("../../lib/memory/read/SearchScope.js");
+
+describe("searchBySemantic 스코프", () => {
+  it("type 지정 시 SQL에 type 조건이 포함된다", async () => {
+    capturedSql = "";
+    await new FragmentReader().searchBySemantic([0.1, 0.2], { type: "decision" }).catch(() => {});
+    assert.ok(capturedSql.includes("f.type = $"), `type 조건 누락: ${capturedSql.slice(0, 200)}`);
+  });
+
+  it("topic 지정 시 SQL에 topic 조건이 포함된다", async () => {
+    capturedSql = "";
+    await new FragmentReader().searchBySemantic([0.1, 0.2], { topic: "infra" }).catch(() => {});
+    assert.ok(capturedSql.includes("f.topic = $"), `topic 조건 누락: ${capturedSql.slice(0, 200)}`);
+  });
+
+  it("미지정 시 조건을 추가하지 않는다", async () => {
+    capturedSql = "";
+    await new FragmentReader().searchBySemantic([0.1, 0.2], {}).catch(() => {});
+    assert.ok(!capturedSql.includes("f.type = $"));
+    assert.ok(!capturedSql.includes("f.topic = $"));
+  });
+});
+
+describe("searchByTimeRange 스코프", () => {
+  it("type/topic 지정 시 SQL 조건이 포함된다", async () => {
+    capturedSql = "";
+    await new FragmentReader().searchByTimeRange("2026-01-01", "2026-02-01",
+      { agentId: "a1", type: "decision", topic: "infra" }).catch(() => {});
+    assert.ok(capturedSql.includes("type = $"), "type 조건 누락");
+    assert.ok(capturedSql.includes("topic = $"), "topic 조건 누락");
+  });
+
+  it("미지정 시 시간창 전체를 수집한다", async () => {
+    capturedSql = "";
+    await new FragmentReader().searchByTimeRange("2026-01-01", "2026-02-01", { agentId: "a1" }).catch(() => {});
+    assert.ok(!capturedSql.includes("type = $"));
+  });
+});
+
+describe("SearchScope type/topic 사후 필터", () => {
+  it("type 불일치 파편을 걸러낸다", () => {
+    const scope = new SearchScope({ type: "decision" });
+    assert.equal(scope.applyTo({ type: "decision", topic: "x" }), true);
+    assert.equal(scope.applyTo({ type: "fact", topic: "x" }), false);
+  });
+
+  it("topic 불일치 파편을 걸러낸다", () => {
+    const scope = new SearchScope({ topic: "infra" });
+    assert.equal(scope.applyTo({ type: "fact", topic: "infra" }), true);
+    assert.equal(scope.applyTo({ type: "fact", topic: "hr" }), false);
+  });
+
+  it("미지정 scope는 no-op으로 판정된다", () => {
+    assert.equal(new SearchScope({}).isNoop(), true);
+    assert.equal(new SearchScope({ type: "fact" }).isNoop(), false);
+    assert.equal(new SearchScope({ topic: "infra" }).isNoop(), false);
+  });
+
+  it("fromQuery가 sq의 type/topic을 전달한다", () => {
+    const scope = SearchScope.fromQuery({ type: "error", topic: "nginx" });
+    assert.equal(scope.type, "error");
+    assert.equal(scope.topic, "nginx");
+  });
+});


### PR DESCRIPTION
운영 피드백에서 보고된 recall 정밀도 문제 중 스코프 누출 부분을 수정한다.

## 문제

`type` 필터가 L1/L2에만 적용되고 있었다. `FragmentReader.searchBySemantic` 시그니처에 `type`/`topic`이 없고, `SearchScope`에도 두 필드가 없어 L3·Graph 결과를 사후에 걸러낼 방어선조차 없었다. `_searchTemporal`은 `agentId/keyId/workspace/caseId/resolutionStatus/phase`만 전달했다.

여기에 RRF가 temporal 레이어에 `timeRange ? 2.0 : 1.0` 가중을 주고(`FragmentSearch.js:441`), `MemoryRecaller`의 depth 사후 필터는 `!params.type` 조건이라 type 지정 시 비활성화된다. 결과적으로 시간창 안의 타입 무관 파편 30건이 2배 가중으로 상위를 점령했다.

운영 이벤트에서 재현됐다. `filter_keys`에 `type`이 있는데 searchPath가 `L1:639 → Temporal:30 → L2:523 → ... → Rerank:15`였고, 해당 호출의 피드백은 "timeRange + type=decision 조합에서 무관한 개인 신상 파편이 상위로 올라옴"이었다.

## 변경

- `SearchScope`에 `type`/`topic` 추가. `applyTo`와 `isNoop`, `fromQuery`에 반영.
- `FragmentReader.searchByTimeRange`에 `type`/`topic` 조건 추가, `_searchTemporal`이 전달.
- `FragmentReader.searchBySemantic`에 `type`/`topic` SQL 조건 추가.
- `searchBySemantic` 시그니처를 옵션 객체로 전환. 위치 인자가 12개에 달해 필터를 더하면 순서 오류 위험이 커진다. 호출부(`FragmentStore`, `FragmentSearch` 2곳)와 기존 테스트 2개 파일을 함께 옮겼다.

## 검증

격리 DB에서 시간창 안에 decision 2건과 fact 6건을 두고 측정했다.

| 항목 | 수정 전 | 수정 후 |
|-|-|-|
| `type=decision` 지정 시 반환 | 8건 (non-decision 6건) | 2건 (non-decision 0건) |
| type 미지정 시 반환 | 8건 | 8건 |

| 항목 | 결과 |
|-|-|
| 신규 유닛 테스트 | 9건 통과 |
| `npm test` | 2312 pass / 0 fail |
| `npm run test:e2e` | 17 pass / 0 fail |
| `npm run lint` | 0 errors |

문서는 `SearchScope` 필드 목록(5개 → 7개)과 `searchBySemantic` 호출 계약을 `SKILL.md`, `docs/internals.md`, `docs/internals.en.md`, `docs/architecture.md`에 반영했다.