### PR TITLE
fix(keywords): 지정 keywords에 본문 추출 결과 병합

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1625,7 +1625,7 @@ reason code 6종 (`code` 필드값):
 | 모든 내용을 하나의 파편에 저장 | 검색 정밀도 저하, 중요도 희석 | 원자적 분해 (1 사실 = 1 파편) |
 | 불필요한 remember 남발 | fragment_limit 쿼터 소진, 노이즈 증가로 검색 품질 저하 | 저장 전 "다음 세션에서 필요한가?" 자문, 일시적 정보는 저장하지 않음 |
 | importance 미지정 (모든 파편 0.5) | recall 시 중요/비중요 파편 구분 불가, 핵심 정보가 노이즈에 묻힘 | 상황별 중요도 기본값 표 참조, 최소 0.6 이상 명시 |
-| keywords 미지정 | 자동 추출에 의존하면 프로젝트명/호스트명 등 핵심 키워드 누락 | 프로젝트명 + 토픽 + 고유 식별자를 keywords에 명시적으로 포함 |
+| keywords 미지정 | 자동 추출에 의존하면 프로젝트명/호스트명 등 핵심 키워드 누락 | 프로젝트명 + 토픽 + 고유 식별자를 keywords에 명시적으로 포함. 지정해도 본문 추출 결과가 병합되므로 본문의 코드 식별자는 별도로 적지 않아도 색인된다 |
 | validation_warnings 무시 후 반복 remember | 동일 경고 파편이 누적되면 symbolic_hard_gate 활성화 시 전면 차단됨 | 경고 내용에 따라 content/linkedTo/resolutionStatus를 보강 후 재저장 |
 | recall 결과의 explanations reasonCodes를 fragment content에 복사 저장 | 검색 품질 메타데이터는 저장하면 안 됨. 노이즈로 검색 정밀도 저하 | reasonCodes는 UI 표시나 컨텍스트 힌트용으로만 사용, 저장 금지 |
 | Shadow mode 없이 Phase 2+ 직행 | 기존 데이터의 claim 백필 없이 explain/policy 활성화 시 경고 오탐 증가 | `MEMENTO_SYMBOLIC_SHADOW=true` + `scripts/backfill-claims.js --dry-run` 선행 후 단계적 활성화 |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -488,7 +488,7 @@ reason code 목록 (최대 3개):
 | content | string | O | 기억할 내용 (1~3문장, 300자 이내 권장). 입력 자체는 최대 4000자까지 허용되며 초과 시 `-32602` 오류로 거부된다 |
 | topic | string | O | 주제 (예: database, email, deployment, security) |
 | type | string | O | 파편 유형. fact, decision, error, preference, procedure, relation, episode. episode 외 타입은 300자 초과 시 절삭. |
-| keywords | string[] | - | 검색용 키워드 (미입력 시 자동 추출) |
+| keywords | string[] | - | 검색용 키워드. 지정해도 본문에서 추출한 키워드가 뒤에 병합되며(중복 제거, 최대 10개) 지정 키워드가 우선한다. 미입력 시 본문 추출만 사용 |
 | importance | number | - | 중요도 0~1 (미입력 시 type별 기본값) |
 | source | string | - | 출처 (세션 ID, 도구명 등) |
 | linkedTo | string[] | - | 연결할 기존 파편 ID 목록 |

--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -194,6 +194,7 @@ Grafana 알림 권장 임계값: `memento_quota_used_total / memento_quota_limit
 | `scripts/post-migrate-flexible-embedding-dims.js` | fragments + morpheme_dict 임베딩 컬럼 차원 동시 조정 | EMBEDDING_DIMENSIONS 변경 또는 provider 전환 시 | 조건부 1회 |
 | `scripts/backfill-claims.js` | 기존 코퍼스에 ClaimExtractor 소급 실행 | Shadow mode(MEMENTO_SYMBOLIC_SHADOW=true) 활성화 전 | 일회성 |
 | `scripts/backfill-split-keywords.js` | keywords가 빈 split 자식 파편에 키워드 소급 생성 | 5.3.1 이하에서 생성된 split 자식이 키워드 검색에 잡히지 않을 때 | 일회성 |
+| `scripts/backfill-body-keywords.js` | 본문 식별자가 keywords에 없는 파편에 추출 결과 소급 병합 | 5.4.1 이하에서 keywords를 지정해 저장한 파편의 코드 식별자가 검색되지 않을 때 | 일회성 |
 | `scripts/benchmark-hot-path.js` | remember/recall/link/reflect 4개 hot path p50/p95/p99 측정 | Symbolic Memory feature flag 전환 전후 회귀 기준선 확보 | 조건부 |
 | `scripts/run-e2e-tests.sh` | Docker 기반 E2E 테스트 실행 | CI/CD 파이프라인 또는 대규모 리팩터링 후 회귀 검증 | CI마다 또는 릴리즈 전 |
 | `scripts/smoke-test-symbolic.sh` | Symbolic Memory end-to-end smoke 검증 | MEMENTO_SYMBOLIC_* 플래그 전환 후 | 조건부 |

--- a/lib/memory/write/FragmentFactory.js
+++ b/lib/memory/write/FragmentFactory.js
@@ -16,6 +16,8 @@ import { sanitizeAffect }             from "./FragmentWriter.js";
 
 const MAX_FRAGMENT_LENGTH         = 300;
 const MAX_EPISODE_FRAGMENT_LENGTH = 1000;
+/** 사용자 지정 keywords와 본문 추출 결과를 병합한 뒤의 상한. 사용자 지정이 앞선다. */
+const MAX_MERGED_KEYWORDS         = 10;
 
 let _tokenEncoder = null;
 
@@ -53,6 +55,32 @@ export function countTokens(text) {
  */
 export function normalizeKeywords(keywords) {
   return keywords.map(k => k.toLowerCase());
+}
+
+/**
+ * 사용자 지정 키워드와 본문 추출 키워드를 병합한다.
+ *
+ * 사용자 지정을 우선 배치하고, 대소문자를 무시한 중복을 제거한 뒤
+ * MAX_MERGED_KEYWORDS까지 추출 결과로 채운다. 추출 항목은 코드 식별자의
+ * 원형을 보존해야 하므로 소문자화하지 않는다.
+ *
+ * @param {string[]} supplied  정규화된 사용자 지정 키워드
+ * @param {string[]} extracted 본문에서 추출한 키워드
+ * @returns {string[]}
+ */
+export function mergeKeywords(supplied, extracted) {
+  const merged = [...supplied];
+  const seen   = new Set(supplied.map(k => k.toLowerCase()));
+
+  for (const kw of extracted) {
+    if (merged.length >= MAX_MERGED_KEYWORDS) break;
+    const key = kw.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(kw);
+  }
+
+  return merged;
 }
 
 const IMPORTANCE_WEIGHT = {
@@ -136,8 +164,14 @@ export class FragmentFactory {
 
     const type       = params.type || "fact";
     const importance = params.importance ?? (IMPORTANCE_WEIGHT[type] || 0.5);
-    const keywords   = params.keywords && params.keywords.length > 0
-      ? normalizeKeywords(params.keywords)
+    /**
+     * 사용자가 keywords를 지정해도 본문 추출을 건너뛰지 않는다.
+     * 지정만 저장하면 본문에만 등장하는 코드 식별자가 색인되지 않아
+     * keywords 배열 교집합을 쓰는 검색 경로에서 회수 자체가 불가능해진다.
+     * 사용자 지정을 앞에 두고 중복을 제거한 뒤 상한까지 추출 결과로 채운다.
+     */
+    const keywords = params.keywords && params.keywords.length > 0
+      ? mergeKeywords(normalizeKeywords(params.keywords), this.extractKeywords(truncated))
       : this.extractKeywords(truncated);
 
     return {

--- a/scripts/backfill-body-keywords.js
+++ b/scripts/backfill-body-keywords.js
@@ -1,0 +1,88 @@
+/**
+ * backfill-body-keywords.js — 본문 식별자가 누락된 파편에 키워드 소급 병합
+ *
+ * 작성자: 최진호
+ * 작성일: 2026-08-02
+ *
+ * 대상: 본문에 코드 식별자(camelCase/snake_case)가 있으나 keywords 배열에는
+ *       식별자가 하나도 없는 유효 파편. 5.4.1 이하에서 사용자가 keywords를
+ *       지정하면 본문 추출이 수행되지 않아 발생했다.
+ * 규칙: 기존 keywords를 앞에 두고 본문 추출 결과를 중복 제거하여 병합한다.
+ *       기존 키워드는 절대 제거하지 않으며 병합 결과가 기존과 같으면 건너뛴다.
+ *       기본은 dryRun. 실제 UPDATE는 --execute 필수.
+ *
+ * 사용:
+ *   node scripts/backfill-body-keywords.js            # 미리보기
+ *   node scripts/backfill-body-keywords.js --execute  # 실제 반영
+ */
+
+import { getPrimaryPool }                      from "../lib/tools/db.js";
+import { FragmentFactory, mergeKeywords }      from "../lib/memory/write/FragmentFactory.js";
+
+const SCHEMA     = "agent_memory";
+const BATCH_SIZE = 500;
+
+const args    = process.argv.slice(2);
+const execute = args.includes("--execute");
+
+async function main() {
+  const pool = getPrimaryPool();
+  if (!pool) {
+    console.error("DB pool unavailable");
+    process.exit(1);
+  }
+
+  const factory = new FragmentFactory();
+
+  /** 본문에 식별자가 있으나 keywords에는 없는 파편만 대상으로 한다. */
+  const { rows } = await pool.query(
+    `SELECT id, content, keywords
+       FROM ${SCHEMA}.fragments
+      WHERE valid_to IS NULL
+        AND content ~ '[a-z][A-Z]'
+        AND NOT EXISTS (SELECT 1 FROM unnest(keywords) k WHERE k ~ '[a-z][A-Z]')`
+  );
+
+  const planned = [];
+  let unchanged = 0;
+
+  for (const f of rows) {
+    const existing = Array.isArray(f.keywords) ? f.keywords : [];
+    const merged   = mergeKeywords(existing, factory.extractKeywords(String(f.content ?? "")));
+
+    if (merged.length === existing.length) {
+      unchanged++;
+      continue;
+    }
+    planned.push({ id: f.id, merged, added: merged.slice(existing.length) });
+  }
+
+  console.log(`대상 ${rows.length}건 중 병합 대상 ${planned.length} / 변화 없음 ${unchanged}`);
+  for (const p of planned.slice(0, 5)) {
+    console.log(`  - ${p.id} :: +[${p.added.join(", ")}]`);
+  }
+
+  if (!execute) {
+    console.log("\ndryRun — 변경 없음. 실제 반영은 --execute.");
+    await pool.end?.();
+    return;
+  }
+
+  let updated = 0;
+  for (const [i, p] of planned.entries()) {
+    const { rowCount } = await pool.query(
+      `UPDATE ${SCHEMA}.fragments SET keywords = $2::text[] WHERE id = $1`,
+      [p.id, p.merged]
+    );
+    updated += rowCount;
+    if ((i + 1) % BATCH_SIZE === 0) console.log(`  진행 ${i + 1}/${planned.length}`);
+  }
+
+  console.log(`\nUPDATE 완료: ${updated}건`);
+  await pool.end?.();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/unit/keyword-merge.test.js
+++ b/tests/unit/keyword-merge.test.js
@@ -1,0 +1,68 @@
+/**
+ * Unit tests: 사용자 지정 keywords와 본문 추출 결과의 병합.
+ *
+ * 지정 keywords만 저장하면 본문에만 등장하는 코드 식별자가 색인되지 않아
+ * keywords 배열 교집합을 쓰는 검색 경로에서 회수가 불가능해진다.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { FragmentFactory, mergeKeywords } = await import("../../lib/memory/write/FragmentFactory.js");
+
+describe("mergeKeywords", () => {
+  it("사용자 지정을 앞에 두고 추출 결과를 뒤에 붙인다", () => {
+    assert.deepEqual(
+      mergeKeywords(["회상", "점수"], ["computeRecallScore", "recall"]),
+      ["회상", "점수", "computeRecallScore", "recall"]
+    );
+  });
+
+  it("대소문자를 무시하고 중복을 제거한다", () => {
+    assert.deepEqual(mergeKeywords(["nginx"], ["NGINX", "포트"]), ["nginx", "포트"]);
+  });
+
+  it("추출 항목의 원형 대소문자를 보존한다", () => {
+    const merged = mergeKeywords(["로그"], ["computeRecallScore"]);
+    assert.ok(merged.includes("computeRecallScore"), "식별자가 소문자화되면 안 된다");
+  });
+
+  it("상한 10개를 넘지 않는다", () => {
+    const supplied  = ["a", "b", "c", "d", "e", "f", "g", "h"];
+    const extracted = ["i", "j", "k", "l", "m"];
+    assert.equal(mergeKeywords(supplied, extracted).length, 10);
+  });
+
+  it("사용자 지정이 상한을 이미 넘으면 그대로 보존한다", () => {
+    const supplied = Array.from({ length: 12 }, (_, i) => `k${i}`);
+    assert.deepEqual(mergeKeywords(supplied, ["extra"]), supplied);
+  });
+
+  it("추출 결과가 비어도 사용자 지정을 잃지 않는다", () => {
+    assert.deepEqual(mergeKeywords(["유일"], []), ["유일"]);
+  });
+});
+
+describe("FragmentFactory.create 키워드 경로", () => {
+  const factory = new FragmentFactory();
+
+  it("keywords 지정 시에도 본문 식별자를 색인한다", () => {
+    const frag = factory.create({
+      content : "recall 점수 산출은 computeRecallScore 함수가 담당한다",
+      topic   : "t",
+      type    : "fact",
+      keywords: ["회상", "점수"]
+    });
+    assert.ok(frag.keywords.includes("회상"), "사용자 지정 보존 필요");
+    assert.ok(frag.keywords.includes("computeRecallScore"), "본문 식별자 색인 필요");
+  });
+
+  it("keywords 미지정 경로는 기존대로 추출만 수행한다", () => {
+    const frag = factory.create({
+      content: "키워드 미지정 파편이며 extractKeywords가 동작해야 한다",
+      topic  : "t",
+      type   : "fact"
+    });
+    assert.ok(frag.keywords.length > 0);
+    assert.ok(frag.keywords.includes("extractKeywords"));
+  });
+});


### PR DESCRIPTION
운영 피드백의 "클래스·메서드명 단위 키워드는 L2 매치가 약함"에 대응한다.

## 문제

`FragmentFactory`가 `params.keywords`를 받으면 `extractKeywords`를 호출하지 않고 지정 배열만 저장했다. `FragmentReader.searchByKeywords`의 조건은 `keywords && $1`과 topic뿐이고 `content`를 보지 않으므로, 본문에만 등장하는 코드 식별자는 회수 자체가 불가능했다. 랭킹 문제가 아니라 색인 부재다.

격리 DB 재현: 본문에 `computeRecallScore`가 있는 파편을 그 식별자로 L2 검색 시 0건.

운영 데이터에서는 본문에 camelCase가 있는 파편 3,032건 중 1,265건(42%, 전체의 13%)이 keywords에 식별자를 갖고 있지 않았다.

## 변경

- `lib/memory/write/FragmentFactory.js`: `mergeKeywords` 추가. 지정 키워드를 앞에 두고 대소문자 무시 중복 제거 후 `MAX_MERGED_KEYWORDS`(10)까지 추출 결과로 채운다. 추출 항목은 식별자 원형 보존을 위해 소문자화하지 않는다.
- `scripts/backfill-body-keywords.js`: 기존 파편 소급 병합. 본문에 식별자가 있으나 keywords에 없는 유효 파편만 대상이며 기존 키워드는 제거하지 않는다. dryRun 기본.
- 문서: `docs/api-reference.md` keywords 설명, `SKILL.md` 안티패턴 표, `docs/operations/maintenance.md` 스크립트 목록.

대체가 아니라 병합을 택한 이유는 사용자가 명시한 키워드를 잃지 않기 위해서다. 지정 키워드가 상한을 이미 넘으면 그대로 보존하고 추출 결과를 붙이지 않는다.

## 검증

| 항목 | 수정 전 | 수정 후 |
|-|-|-|
| 식별자로 L2 검색 | 0건 | 1건 |
| 저장된 keywords | `[회상, 점수, 산출]` | `[회상, 점수, 산출, computeRecallScore, rerankerScore, recall]` |

| 항목 | 결과 |
|-|-|
| 신규 유닛 테스트 | 8건 통과 |
| `npm test` | 2320 pass / 0 fail |
| `npm run test:e2e` | 17 pass / 0 fail |
| `npm run lint` | 0 errors |

백필 스크립트는 dryRun에서 대상과 추가될 키워드를 보고하고 DB를 변경하지 않는 것을 확인했다.