### PR TITLE
fix(recall): 형태소 보조 검색 설정 연결

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,8 @@ macOS launchd로 서버를 실행하는 경우 셸 프로필을 읽지 않으므
 
 이 값은 `MEMENTO_MORPHEME_TOKENIZER=llm` 설정 시 `MorphemeIndex._tokenizeViaLLM()` 내부의 `geminiCLIJson(userPrompt, { timeoutMs: cfg.geminiTimeoutMs })` 호출에 전달된다. 기본값(`MEMENTO_MORPHEME_TOKENIZER=local`)에서는 로컬 분석기(MorphemeTokenizer)를 사용하므로 이 값은 참조되지 않는다. LLM 경로에서 tokenize가 실패하면 형태소 추출 결과가 없으므로 L3 morpheme 검색(recall의 전문 검색 경로)이 비활성화된 것과 동일하게 동작한다 (`_fallbackTokenize` 로 graceful degrade).
 
+**형태소 보조 검색(morphemeIndex.minSimilarity / fallbackThreshold / fallbackLimit)**: L3 시맨틱 검색과 병렬로 형태소 평균 벡터 기반 보조 검색을 수행한다. 형태소 평균 벡터는 문장 임베딩보다 코사인 유사도가 체계적으로 낮으므로 전용 임계값 `morphemeIndex.minSimilarity`(기본 0.15)를 사용하며, `semanticSearch.minSimilarity`(기본 0.4)를 재사용하지 않는다. 기본 L3 결과 수가 `fallbackThreshold`(기본 5) 이하일 때만 보조 결과를 채택하고, 채택 시 `fallbackLimit`(기본 5)개까지 병합한다. 프로브 자체는 병렬 실행되므로 채택 여부가 응답 지연에 영향을 주지 않는다.
+
 **GEMINI_TIMEOUT_MS**: `lib/memory/processors/AutoReflect.js`의 LLM chain 호출 timeout은 30,000 ms로 고정된다(`GEMINI_TIMEOUT_MS = 30_000` 코드 상수, `process.env` 참조 없음). 값을 변경하려면 해당 파일의 상수를 직접 수정해야 한다. MorphemeIndex의 `geminiTimeoutMs`(config/memory.js, 기본 60000)와 별개임에 주의한다.
 
 **buildChain 순서 결정 로직** (`lib/llm/index.js:38–68`): `LLM_PRIMARY` → `LLM_FALLBACKS` 선언 순서로 entries 배열을 구성한 뒤, `seen` Set으로 중복 provider를 제거하고, 각 provider의 `isAvailable()` 체크 성공 여부로 chain에 포함 여부를 결정한다. `LLM_PRIMARY`가 `LLM_FALLBACKS` 목록에도 있으면 fallback의 config 객체가 우선 사용된다. `isAvailable()` 실패 시 해당 provider는 체인에서 제외되고 다음 provider로 즉시 넘어간다. 결과적으로 chain 순서는 환경변수 선언 순서와 1:1 대응한다.

--- a/lib/memory/read/FragmentSearch.js
+++ b/lib/memory/read/FragmentSearch.js
@@ -751,6 +751,13 @@ export class FragmentSearch {
       const adaptedSim    = await (query._adaptedSimPromise ?? Promise.resolve(null));
       const minSimilarity = adaptedSim ?? cfgSim ?? 0.35;
 
+      /** 형태소 보조 검색 전용 설정. 형태소 평균 벡터는 문장 임베딩보다 코사인이
+       *  체계적으로 낮으므로 L3와 같은 임계값을 쓰면 사실상 전량 탈락한다. */
+      const morphCfg      = MEMORY_CONFIG.morphemeIndex || {};
+      const morphMinSim   = morphCfg.minSimilarity     ?? 0.15;
+      const morphLimit    = morphCfg.fallbackLimit     ?? 5;
+      const morphThresh   = morphCfg.fallbackThreshold ?? 5;
+
       /** 기본 시맨틱 검색과 morpheme 보강 검색을 병렬 실행한다.
        *  _skipMorpheme(keywords 합성 텍스트 등 형태소 분석 무의미한 입력)은 즉시 [] 반환. */
       const morphemeProbe = query._skipMorpheme === true ? Promise.resolve([]) : (async () => {
@@ -758,8 +765,8 @@ export class FragmentSearch {
           const morphemeVec = await this._morphemeIndex.textToMorphemeVector(query.text);
           if (!morphemeVec) return [];
           return await this.store.searchBySemantic(morphemeVec, {
-            limit            : Math.min(limit ?? 10, 10),
-            minSimilarity,
+            limit            : morphLimit,
+            minSimilarity    : morphMinSim,
             agentId, keyId,
             includeSuperseded: query.includeSuperseded || false,
             timeRange,
@@ -798,12 +805,17 @@ export class FragmentSearch {
         boostAssistantFragments(results);
       }
 
-      /** 기본 L3 결과 + morpheme 결과 병합 (중복 ID는 기본 결과 우선) */
-      if (morphemeResults.length > 0) {
+      /** 기본 L3 결과 + morpheme 결과 병합 (중복 ID는 기본 결과 우선).
+       *  fallbackThreshold 초과로 기본 결과가 충분하면 보조 결과를 채택하지 않는다.
+       *  프로브 자체는 병렬로 이미 끝나 있으므로 채택 여부가 지연에 영향을 주지 않는다. */
+      if (morphemeResults.length > 0 && results.length <= morphThresh) {
         const seen = new Set(results.map(f => f.id));
+        let added  = 0;
         for (const f of morphemeResults) {
+          if (added >= morphLimit) break;
           if (!seen.has(f.id)) {
             results.push(f);
+            added++;
           }
         }
       }

--- a/tests/unit/morpheme-fallback-config.test.js
+++ b/tests/unit/morpheme-fallback-config.test.js
@@ -1,0 +1,44 @@
+/**
+ * Unit tests: morphemeIndex 설정이 형태소 보조 검색에 실제로 연결되는지 검증.
+ *
+ * minSimilarity / fallbackThreshold / fallbackLimit 세 키는 설정 파일과
+ * validate-memory-config에는 존재하지만 검색 경로에서 소비되지 않고 있었다.
+ * 형태소 평균 벡터는 문장 임베딩보다 코사인이 낮아 L3 임계값(0.4)에서 전량 탈락한다.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { MEMORY_CONFIG } = await import("../../config/memory.js");
+const { FragmentSearch } = await import("../../lib/memory/read/FragmentSearch.js");
+
+const src = FragmentSearch.prototype._searchL3.toString();
+
+describe("morphemeIndex 설정 연결", () => {
+  it("형태소 전용 minSimilarity를 참조한다", () => {
+    assert.ok(src.includes("morphCfg.minSimilarity"), "morphemeIndex.minSimilarity 미참조");
+  });
+
+  it("fallbackLimit을 참조한다", () => {
+    assert.ok(src.includes("morphCfg.fallbackLimit"), "fallbackLimit 미참조");
+  });
+
+  it("fallbackThreshold를 참조한다", () => {
+    assert.ok(src.includes("morphCfg.fallbackThreshold"), "fallbackThreshold 미참조");
+  });
+
+  it("형태소 프로브가 L3 임계값을 재사용하지 않는다", () => {
+    /** 프로브 호출 블록에 minSimilarity: morphMinSim 형태가 있어야 한다 */
+    assert.ok(src.includes("minSimilarity    : morphMinSim") || src.includes("minSimilarity: morphMinSim"),
+      "형태소 프로브가 전용 임계값을 사용해야 한다");
+  });
+
+  it("설정 기본값이 L3보다 낮게 유지된다", () => {
+    const l3    = MEMORY_CONFIG.semanticSearch.minSimilarity;
+    const morph = MEMORY_CONFIG.morphemeIndex.minSimilarity;
+    assert.ok(morph < l3, `형태소 임계값(${morph})은 L3(${l3})보다 낮아야 한다`);
+  });
+
+  it("기본 결과가 충분하면 보조 결과를 채택하지 않는 게이트가 있다", () => {
+    assert.ok(src.includes("results.length <= morphThresh"), "fallbackThreshold 게이트 필요");
+  });
+});


### PR DESCRIPTION
운영 피드백의 recall 회수 부족 문제 중 형태소 경로를 수정한다.

## 문제

`config/memory.js`의 `morphemeIndex` 설정 중 세 키가 코드에서 소비되지 않았다.

| 키 | 기본값 | 주석에 적힌 의도 | 실제 |
|-|-|-|-|
| `minSimilarity` | 0.15 | fallback 최소 유사도, L3보다 낮게 설정 | 미참조. 프로브가 `semanticSearch.minSimilarity`(0.4) 사용 |
| `fallbackThreshold` | 5 | L3 결과가 이 수 이하일 때 fallback 실행 | 미참조. 항상 병렬 실행 후 무조건 병합 |
| `fallbackLimit` | 5 | fallback 최대 반환 파편 수 | 미참조 |

형태소 평균 벡터는 문장 임베딩보다 코사인 유사도가 체계적으로 낮으므로 0.4 임계값에서는 사실상 전량 탈락한다. 설계된 보조 검색이 동작하지 않는 상태였다.

`config/validate-memory-config.js:35`는 `morphemeIndex.minSimilarity`를 0~1 범위로 검증하고 있었다. 값의 유효성은 강제하면서 소비하는 코드가 없는 상태였다.

## 변경

- `lib/memory/read/FragmentSearch.js`: 형태소 프로브가 전용 임계값과 `fallbackLimit`을 사용한다. 병합 시 기본 L3 결과가 `fallbackThreshold` 이하일 때만 보조 결과를 채택하고 `fallbackLimit`개까지 추가한다.
- `docs/configuration.md`: 세 키의 동작 문서화.

프로브 실행 자체는 기존대로 병렬로 둔다. 순차 실행으로 바꾸면 보조 검색이 필요한 희소 결과 쿼리에서만 지연이 늘어나는데, 그 쿼리가 정확히 개선 대상이라 역효과다. 채택 게이트만 적용하면 지연 변화 없이 설계 의도를 만족한다.

## 검증

| 항목 | 결과 |
|-|-|
| 설정 키 참조 수 (수정 전 → 후) | 0 → 각 1 |
| 신규 유닛 테스트 | 6건 통과 |
| `npm test` | 2326 pass / 0 fail |
| `npm run lint` | 0 errors |

이 항목을 마지막에 배치한 이유는 임계값 효과가 후보 분포에 의존하기 때문이다. 색인 부재(#45)와 스코프 누출(#44)이 남은 상태에서 조정하면 결함 데이터에 맞춰 고정된다.